### PR TITLE
fix mbap payload length

### DIFF
--- a/tcpport.js
+++ b/tcpport.js
@@ -83,7 +83,8 @@ TcpPort.prototype.write = function (data) {
     var buffer = new Buffer(data.length + 6 - 2);
     buffer.writeUInt16BE(1, 0);
     buffer.writeUInt16BE(0, 2);
-    buffer.writeUInt16BE(data.length, 4);
+    // subtract crc bytes
+    buffer.writeUInt16BE(data.length - 2, 4);
     data.copy(buffer, 6);
     
     // send buffer to slave


### PR DESCRIPTION
Even though it's not copied to the payload, data already includes the CRC. This leads to an invalid payload length in the MBAP header.