### PR TITLE
Ascii serial support

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -2,16 +2,16 @@
 /**
  * Copyright (c) 2015, Yaacov Zamir <kobi.zamir@gmail.com>
  *
- * Permission to use, copy, modify, and/or distribute this software for any 
- * purpose with or without fee is hereby granted, provided that the above 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES 
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR 
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES 
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN 
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF  THIS SOFTWARE.
  */
 
@@ -21,10 +21,10 @@
  * @param {ModbusRTU} Modbus the ModbusRTU object.
  */
 var addConnctionAPI = function(Modbus) {
-    
+
     var cl = Modbus.prototype;
-    
-    /** 
+
+    /**
      * Connect to a communication port, using SerialPort.
      *
      * @param {string} path the path to the Serial Port - required.
@@ -37,19 +37,19 @@ var addConnctionAPI = function(Modbus) {
             next = options;
             options = {};
         }
-        
+
         // create the SerialPort
         var SerialPort = require("serialport").SerialPort;
         var serialPort = new SerialPort(path, options);
-        
+
         // re-set the serial port to use
         this._port = serialPort;
-        
+
         // open and call next
         this.open(next);
     }
 
-    /** 
+    /**
      * Connect to a communication port, using TcpPort.
      *
      * @param {string} ip the ip of the TCP Port - required.
@@ -58,25 +58,25 @@ var addConnctionAPI = function(Modbus) {
      */
     cl.connectTCP = function (ip, options, next) {
         var port;
-        
+
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
             options = {};
         }
-        
+
         // create the TcpPort
         var TcpPort = require('../ports/tcpport');
         var tcpPort = new TcpPort(ip, options);
-        
+
         // re-set the port to use
         this._port = tcpPort;
-        
+
         // open and call next
         this.open(next);
     }
-    
-    /** 
+
+    /**
      * Connect to a communication port, using TelnetPort.
      *
      * @param {string} ip the ip of the TelnetPort - required.
@@ -85,25 +85,25 @@ var addConnctionAPI = function(Modbus) {
      */
     cl.connectTelnet = function (ip, options, next) {
         var port;
-        
+
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
             options = {};
         }
-        
+
         // create the TcpPort
         var TelnetPort = require('../ports/telnetport');
         var telnetPort = new TelnetPort(ip, options);
-        
+
         // re-set the port to use
         this._port = telnetPort;
-        
+
         // open and call next
         this.open(next);
     }
-    
-    /** 
+
+    /**
      * Connect to a communication port, using C701 UDP-to-Serial bridge.
      *
      * @param {string} ip the ip of the TelnetPort - required.
@@ -112,25 +112,25 @@ var addConnctionAPI = function(Modbus) {
      */
     cl.connectC701 = function (ip, options, next) {
         var port;
-        
+
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
             options = {};
         }
-        
+
         // create the TcpPort
         var C701Port = require('../ports/c701port');
         var c701Port = new C701Port(ip, options);
-        
+
         // re-set the port to use
         this._port = c701Port;
-        
+
         // open and call next
         this.open(next);
     }
-    
-    /** 
+
+    /**
      * Connect to a communication port, using Bufferd Serial port.
      *
      * @param {string} path the path to the Serial Port - required.
@@ -143,17 +143,42 @@ var addConnctionAPI = function(Modbus) {
             next = options;
             options = {};
         }
-        
+
         // create the SerialPort
         var SerialPort = require('../ports/rtubufferedport');
         var serialPort = new SerialPort(path, options);
-        
+
         // re-set the serial port to use
         this._port = serialPort;
-        
+
         // open and call next
         this.open(next);
     }
+
+    /**
+     * Connect to a communication port, using ASCII Serial port.
+     *
+     * @param {string} path the path to the Serial Port - required.
+     * @param {object} options - the serial port options - optional.
+     * @param {function} next the function to call next.
+     */
+    cl.connectAsciiSerial = function (path, options, next) {
+        // check if we have options
+        if (typeof(next) == 'undefined' && typeof(options) == 'function') {
+            next = options;
+            options = {};
+        }
+
+        // create the ASCII SerialPort
+        var SerialPortAscii = require('../ports/asciiport');
+        var serialPortAscii = new SerialPortAscii(path, options);
+
+        // re-set the serial port to use
+        this._port = serialPortAscii;
+
+         // open and call next
+         this.open(next);
+     }
 }
 
 module.exports = addConnctionAPI;

--- a/index.js
+++ b/index.js
@@ -232,15 +232,15 @@ ModbusRTU.prototype.open = function (callback) {
 
                 /* check for modbus exception
                  */
-                if (data.length == 5 && 
-                        address != modbus._nextAddress && 
+                if (data.length == 5 &&
                         code == (0x80 & modbus._nextCode)) {
-                    error = "Modbus exception " + data.readUInt8(3);
+//                    error = "Modbus exception " + data.readUInt8(3);
+                    error = "Modbus exception " + data.readUInt8(2);
                     if (next)
                         next(error);
                     return;
                 }
-                
+
                 /* check message length
                  * if we do not expect this data
                  * raise an error

--- a/index.js
+++ b/index.js
@@ -233,8 +233,7 @@ ModbusRTU.prototype.open = function (callback) {
                 /* check for modbus exception
                  */
                 if (data.length == 5 &&
-                        code == (0x80 & modbus._nextCode)) {
-//                    error = "Modbus exception " + data.readUInt8(3);
+                        code == (0x80 | modbus._nextCode)) {
                     error = "Modbus exception " + data.readUInt8(2);
                     if (next)
                         next(error);

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -165,8 +165,8 @@ var AsciiPort = function(path, options) {
             }
 
             // we have what looks like a complete ascii encoded response message, so decode
-            var _data = asciiDecodeResponseBuffer();
-            if( _data() !== null ) {
+            var _data = asciiDecodeResponseBuffer(modbus._buffer);
+            if( _data !== null ) {
 
                 // check if this is the data we are waiting for
                 if (checkData(modbus, _data)) {
@@ -240,7 +240,7 @@ AsciiPort.prototype.write = function (data) {
     var _encodedData = asciiEncodeRequestBuffer(data);
 
     // send buffer to slave
-    this._client.write(data);
+    this._client.write(_encodedData);
 }
 
 module.exports = AsciiPort;

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -1,0 +1,246 @@
+'use strict';
+var util = require('util');
+var events = require('events');
+var SerialPort = require("serialport").SerialPort;
+
+/**
+ * calculate crc16
+ *
+ * @param {buffer} buf the buffer to to crc on.
+ * @return {number} the calculated crc16
+ */
+function crc16(buf) {
+    var length = buf.length - 2;
+    var crc = 0xFFFF;
+    var tmp;
+
+    // calculate crc16
+    for (var i = 0; i < length; i++) {
+        crc = crc ^ buf[i];
+
+        for (var j = 0; j < 8; j++) {
+            tmp = crc & 0x0001;
+            crc = crc >> 1;
+            if (tmp) {
+              crc = crc ^ 0xA001;
+            }
+        }
+    }
+
+    return crc;
+}
+
+/**
+ * calculate lrc
+ *
+ * @param {buffer} buf the buffer to to lrc on.
+ * @return {number} the calculated lrc
+ */
+function calculateLrc (buf) {
+    var length = buf.length - 2;
+
+    var lrc = 0;
+    for (var i = 0; i < length; i++) {
+         lrc += buf[i] & 0xFF;
+     }
+
+     return ((lrc ^ 0xFF) + 1) & 0xFF;
+}
+
+/**
+ * Ascii encode a 'request' buffer and return it. This includes removing
+ * the CRC bytes and replacing them with an LRC.
+ *
+ * @param {buffer} buf the data buffer to encode.
+ * @return {buffer} the ascii encoded buffer
+ */
+function asciiEncodeRequestBuffer(buf) {
+
+    // replace the 2 byte crc16 with a single byte lrc
+    buf.writeUInt8(calculateLrc(buf), buf.length-2);
+
+    // create a new buffer of the correct size
+    var bufAscii = new Buffer(buf.length*2 + 1); // 1 byte start delimit + x2 data as ascii encoded + 2 lrc + 2 end delimit
+
+    // create the ascii payload
+
+    // start with the single start delimiter
+    bufAscii.write(':', 0);
+    // encode the data, with the new single byte lrc
+    bufAscii.write(buf.toString('hex', 0, buf.length-1).toUpperCase(), 1);
+    // end with the two end delimiters
+    bufAscii.write('\r', bufAscii.length-2);
+    bufAscii.write('\n', bufAscii.length-1);
+
+    return bufAscii;
+}
+
+/**
+ * Ascii decode a 'response' buffer and return it.
+ *
+ * @param {buffer} bufAscii the ascii data buffer to decode.
+ * @return {buffer} the decoded buffer, or null if decode error
+ */
+function asciiDecodeResponseBuffer(bufAscii) {
+
+    // create a new buffer of the correct size (based on ascii encoded buffer length)
+    var bufDecoded = new Buffer( (bufAscii.length-1)/2 );
+
+    // decode into new buffer (removing delimiters at start and end)
+    for (var i = 0; i < (bufAscii.length-3)/2; i++) {
+        bufDecoded.write(String.fromCharCode(bufAscii.readUInt8(i*2+1), bufAscii.readUInt8(i*2+2)), i, 1, 'hex');
+    }
+
+    // check the lrc is true
+    var lrcIn = bufDecoded.readUInt8(bufDecoded.length - 2);
+    if( calculateLrc(bufDecoded) != lrcIn ) {
+        // retun null if lrc error
+        return null;
+    }
+
+    // replace the 1 byte lrc with a two byte crc16
+    bufDecoded.writeUInt16LE(crc16(bufDecoded), bufDecoded.length-2);
+
+    return bufDecoded;
+}
+
+/**
+ * check if a buffer chunk can be a modbus answer
+ * or modbus exception
+ *
+ * @param {buffer} buf the buffer to check.
+ * @return {boolean} if the buffer can be an answer
+ */
+function checkData(modbus, buf) {
+    // check buffer size
+    if (buf.length != modbus._length && buf.length != 5) return false;
+
+    // check buffer unit-id and command
+    return (buf[0] == modbus._id &&
+        (0x7f & buf[1]) == modbus._cmd);
+}
+
+/**
+ * Simulate a modbus-ascii port using serial connection
+ */
+var AsciiPort = function(path, options) {
+    var modbus = this;
+
+    // options
+    if (typeof(options) == 'undefined') options = {};
+
+    // internal buffer
+    this._buffer = new Buffer(0);
+    this._id = 0;
+    this._cmd = 0;
+    this._length = 0;
+
+    // create the SerialPort
+    this._client= new SerialPort(path, options);
+
+    // register the port data event
+    this._client.on('data', function(data) {
+
+        // add new data to buffer
+        modbus._buffer = Buffer.concat([modbus._buffer, data]);
+
+        // check buffer for start delimiter
+        var sdIndex = modbus._buffer.indexOf(0x3A); // ascii for ':'
+        if( sdIndex === -1) {
+            // if not there, reset the buffer and return
+            modbus._buffer = new Buffer(0);
+            return;
+        }
+        // if there is data before the start delimiter, remove it
+        if( sdIndex > 0 ) {
+            modbus._buffer = modbus._buffer.slice(sdIndex);
+        }
+        // do we have the complete message (i.e. are the end delimiters there)
+        if( modbus._buffer.includes('\r\n', 1, 'ascii') === true ) {
+            // check there is no excess data after end delimiters
+            var edIndex = modbus._buffer.indexOf(0x0A); // ascii for '\n'
+            if(edIndex != modbus._buffer.length-1) {
+                // if there is, remove it
+                modbus._buffer = modbus._buffer.slice(0, edIndex+1);
+            }
+
+            // we have what looks like a complete ascii encoded response message, so decode
+            var _data = asciiDecodeResponseBuffer();
+            if( _data() !== null ) {
+
+                // check if this is the data we are waiting for
+                if (checkData(modbus, _data)) {
+                    // emit a data signal
+                    modbus.emit('data', _data);
+                }
+            }
+            // reset the buffer now its been used
+            modbus._buffer = new Buffer(0);
+        } else {
+            // otherwise just wait for more data to arrive
+        }
+    });
+
+    events.call(this);
+}
+util.inherits(AsciiPort, events);
+
+/**
+ * Simulate successful port open
+ */
+AsciiPort.prototype.open = function (callback) {
+    this._client.open(callback);
+}
+
+/**
+ * Simulate successful close port
+ */
+AsciiPort.prototype.close = function (callback) {
+    this._client.close(callback);
+}
+/**
+ * Send data to a modbus slave via telnet server
+ */
+AsciiPort.prototype.write = function (data) {
+    // check data length
+    if (data.length < 6) {
+        // raise an error ?
+        return;
+    }
+
+    // remember current unit and command
+    this._id = data[0];
+    this._cmd = data[1];
+
+    // calculate expected answer length (this is checked after ascii decoding)
+    switch (this._cmd) {
+        case 1:
+        case 2:
+            var length = data.readUInt16BE(4);
+            this._length = 3 + parseInt((length - 1) / 8 + 1) + 2;
+            break;
+        case 3:
+        case 4:
+            var length = data.readUInt16BE(4);
+            this._length = 3 + 2 * length + 2;
+            break;
+        case 5:
+        case 6:
+        case 15:
+        case 16:
+            this._length = 6 + 2;
+            break;
+        default:
+            // raise and error ?
+            this._length = 0;
+            break;
+    }
+
+    // ascii encode buffer
+    var _encodedData = asciiEncodeRequestBuffer(data);
+
+    // send buffer to slave
+    this._client.write(data);
+}
+
+module.exports = AsciiPort;


### PR DESCRIPTION
Hi I have added a new port to support the ASCII mode of serial.
It uses a different error correction method (lrc) but I have made this transparent to the higher levels by checking the lrc at the port level and swaping in a crc header for your higher level index.js to check. This is similar to the method you used for tcp port.

I have also tweaked the error detection logic in index.js to pick up exception responses correctly.

I have tested all of this using "Simply Modbus Slave 8.0.3" running in ASCII mode.