### PR TITLE
Call serial device open function with 'auto open' option disabled

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -40,7 +40,7 @@ var addConnctionAPI = function(Modbus) {
 
         // create the SerialPort
         var SerialPort = require("serialport").SerialPort;
-        var serialPort = new SerialPort(path, options);
+        var serialPort = new SerialPort(path, options, false);
 
         // re-set the serial port to use
         this._port = serialPort;

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -136,7 +136,7 @@ var AsciiPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client= new SerialPort(path, options);
+    this._client= new SerialPort(path, options, false);
 
     // register the port data event
     this._client.on('data', function(data) {

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -66,7 +66,7 @@ var RTUBufferedPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client= new SerialPort(path, options);
+    this._client= new SerialPort(path, options, false);
 
     // register the port data event
     this._client.on('data', function(data) {


### PR DESCRIPTION
- This should be disabled as we call open separately afterwards
- Fixes instability issue I have seen on rpi2 with ftdi usb serial device