### PR TITLE
Fixes yaacov/node-modbus-serial#9

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,6 +491,10 @@ ModbusRTU.prototype.writeFC15 = function (address, dataAddress, array, next) {
     buf.writeUInt16BE(array.length, 4);
     buf.writeUInt8(dataBytes, 6);
 
+    while (array.length % 8) {
+        array.push(false);
+    }
+
     for (var i = 0; i < array.length; i++) {
         buf.writeBit(array[i], i, 7);
     }


### PR DESCRIPTION
Simple for-loop will push 0-bits to the buffer until all bits of the byte are set.

Fixes yaacov/node-modbus-serial#9