### PR TITLE
Fix references to built-in objects in JSDoc. Extract crc16 function.

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -28,8 +28,8 @@ var addConnctionAPI = function(Modbus) {
      * Connect to a communication port, using SerialPort.
      *
      * @param {string} path the path to the Serial Port - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectRTU = function (path, options, next) {
         // check if we have options
@@ -40,25 +40,20 @@ var addConnctionAPI = function(Modbus) {
 
         // create the SerialPort
         var SerialPort = require("serialport").SerialPort;
-        var serialPort = new SerialPort(path, options, false);
-
-        // re-set the serial port to use
-        this._port = serialPort;
+        this._port = new SerialPort(path, options, false);
 
         // open and call next
         this.open(next);
-    }
+    };
 
     /**
      * Connect to a communication port, using TcpPort.
      *
      * @param {string} ip the ip of the TCP Port - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectTCP = function (ip, options, next) {
-        var port;
-
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
@@ -67,25 +62,20 @@ var addConnctionAPI = function(Modbus) {
 
         // create the TcpPort
         var TcpPort = require('../ports/tcpport');
-        var tcpPort = new TcpPort(ip, options);
-
-        // re-set the port to use
-        this._port = tcpPort;
+        this._port = new TcpPort(ip, options);
 
         // open and call next
         this.open(next);
-    }
+    };
 
     /**
      * Connect to a communication port, using TelnetPort.
      *
      * @param {string} ip the ip of the TelnetPort - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectTelnet = function (ip, options, next) {
-        var port;
-
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
@@ -94,25 +84,20 @@ var addConnctionAPI = function(Modbus) {
 
         // create the TcpPort
         var TelnetPort = require('../ports/telnetport');
-        var telnetPort = new TelnetPort(ip, options);
-
-        // re-set the port to use
-        this._port = telnetPort;
+        this._port = new TelnetPort(ip, options);
 
         // open and call next
         this.open(next);
-    }
+    };
 
     /**
      * Connect to a communication port, using C701 UDP-to-Serial bridge.
      *
      * @param {string} ip the ip of the TelnetPort - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectC701 = function (ip, options, next) {
-        var port;
-
         // check if we have options
         if (typeof(next) == 'undefined' && typeof(options) == 'function') {
             next = options;
@@ -121,21 +106,18 @@ var addConnctionAPI = function(Modbus) {
 
         // create the TcpPort
         var C701Port = require('../ports/c701port');
-        var c701Port = new C701Port(ip, options);
-
-        // re-set the port to use
-        this._port = c701Port;
+        this._port = new C701Port(ip, options);
 
         // open and call next
         this.open(next);
-    }
+    };
 
     /**
      * Connect to a communication port, using Bufferd Serial port.
      *
      * @param {string} path the path to the Serial Port - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectRTUBuffered = function (path, options, next) {
         // check if we have options
@@ -146,21 +128,18 @@ var addConnctionAPI = function(Modbus) {
 
         // create the SerialPort
         var SerialPort = require('../ports/rtubufferedport');
-        var serialPort = new SerialPort(path, options);
-
-        // re-set the serial port to use
-        this._port = serialPort;
+        this._port = new SerialPort(path, options);
 
         // open and call next
         this.open(next);
-    }
+    };
 
     /**
      * Connect to a communication port, using ASCII Serial port.
      *
      * @param {string} path the path to the Serial Port - required.
-     * @param {object} options - the serial port options - optional.
-     * @param {function} next the function to call next.
+     * @param {Object} options - the serial port options - optional.
+     * @param {Function} next the function to call next.
      */
     cl.connectAsciiSerial = function (path, options, next) {
         // check if we have options
@@ -171,14 +150,11 @@ var addConnctionAPI = function(Modbus) {
 
         // create the ASCII SerialPort
         var SerialPortAscii = require('../ports/asciiport');
-        var serialPortAscii = new SerialPortAscii(path, options);
-
-        // re-set the serial port to use
-        this._port = serialPortAscii;
+        this._port = new SerialPortAscii(path, options);
 
          // open and call next
          this.open(next);
      }
-}
+};
 
 module.exports = addConnctionAPI;

--- a/apis/promise.js
+++ b/apis/promise.js
@@ -18,7 +18,7 @@
 /**
  * Take a modbus serial function and convert it to use promises.
  *
- * @param {function} f the function to convert
+ * @param {Function} f the function to convert
  * @return a function that calls function "f" and return a promise.
  */
 var convert = function(f) {
@@ -49,10 +49,10 @@ var convert = function(f) {
 
             return promise;
         }
-    }
+    };
 
     return converted;
-}
+};
 
 /**
  * Adds promise API to a Modbus objext
@@ -64,8 +64,8 @@ var addPromiseAPI = function(Modbus) {
     var cl = Modbus.prototype;
 
     // set/get unitID
-    cl.setID = function(id) {this._unitID = id;}
-    cl.getID = function() {return this._unitID;}
+    cl.setID = function(id) {this._unitID = id;};
+    cl.getID = function() {return this._unitID;};
 
     // convert functions to return promises
     cl.readCoils = convert(cl.writeFC1);
@@ -75,6 +75,6 @@ var addPromiseAPI = function(Modbus) {
     cl.writeCoil = convert(cl.writeFC5);
     cl.writeRegister  = convert(cl.writeFC6);
     cl.writeRegisters = convert(cl.writeFC16);
-}
+};
 
 module.exports = addPromiseAPI;

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -3,37 +3,12 @@ var util = require('util');
 var events = require('events');
 var SerialPort = require("serialport").SerialPort;
 
-/**
- * calculate crc16
- *
- * @param {buffer} buf the buffer to to crc on.
- * @return {number} the calculated crc16
- */
-function crc16(buf) {
-    var length = buf.length - 2;
-    var crc = 0xFFFF;
-    var tmp;
-
-    // calculate crc16
-    for (var i = 0; i < length; i++) {
-        crc = crc ^ buf[i];
-
-        for (var j = 0; j < 8; j++) {
-            tmp = crc & 0x0001;
-            crc = crc >> 1;
-            if (tmp) {
-              crc = crc ^ 0xA001;
-            }
-        }
-    }
-
-    return crc;
-}
+var crc16 = require('./../utils/crc16');
 
 /**
  * calculate lrc
  *
- * @param {buffer} buf the buffer to to lrc on.
+ * @param {Buffer} buf the buffer to to lrc on.
  * @return {number} the calculated lrc
  */
 function calculateLrc (buf) {
@@ -51,8 +26,8 @@ function calculateLrc (buf) {
  * Ascii encode a 'request' buffer and return it. This includes removing
  * the CRC bytes and replacing them with an LRC.
  *
- * @param {buffer} buf the data buffer to encode.
- * @return {buffer} the ascii encoded buffer
+ * @param {Buffer} buf the data buffer to encode.
+ * @return {Buffer} the ascii encoded buffer
  */
 function asciiEncodeRequestBuffer(buf) {
 
@@ -78,8 +53,8 @@ function asciiEncodeRequestBuffer(buf) {
 /**
  * Ascii decode a 'response' buffer and return it.
  *
- * @param {buffer} bufAscii the ascii data buffer to decode.
- * @return {buffer} the decoded buffer, or null if decode error
+ * @param {Buffer} bufAscii the ascii data buffer to decode.
+ * @return {Buffer} the decoded buffer, or null if decode error
  */
 function asciiDecodeResponseBuffer(bufAscii) {
 
@@ -94,7 +69,7 @@ function asciiDecodeResponseBuffer(bufAscii) {
     // check the lrc is true
     var lrcIn = bufDecoded.readUInt8(bufDecoded.length - 2);
     if( calculateLrc(bufDecoded) != lrcIn ) {
-        // retun null if lrc error
+        // return null if lrc error
         return null;
     }
 
@@ -108,7 +83,8 @@ function asciiDecodeResponseBuffer(bufAscii) {
  * check if a buffer chunk can be a modbus answer
  * or modbus exception
  *
- * @param {buffer} buf the buffer to check.
+ * @param {AsciiPort} modbus
+ * @param {Buffer} buf the buffer to check.
  * @return {boolean} if the buffer can be an answer
  */
 function checkData(modbus, buf) {
@@ -127,7 +103,7 @@ var AsciiPort = function(path, options) {
     var modbus = this;
 
     // options
-    if (typeof(options) == 'undefined') options = {};
+    options = options || {};
 
     // internal buffer
     this._buffer = new Buffer(0);
@@ -182,7 +158,7 @@ var AsciiPort = function(path, options) {
     });
 
     events.call(this);
-}
+};
 util.inherits(AsciiPort, events);
 
 /**
@@ -190,14 +166,15 @@ util.inherits(AsciiPort, events);
  */
 AsciiPort.prototype.open = function (callback) {
     this._client.open(callback);
-}
+};
 
 /**
  * Simulate successful close port
  */
 AsciiPort.prototype.close = function (callback) {
     this._client.close(callback);
-}
+};
+
 /**
  * Send data to a modbus slave via telnet server
  */
@@ -241,6 +218,6 @@ AsciiPort.prototype.write = function (data) {
 
     // send buffer to slave
     this._client.write(_encodedData);
-}
+};
 
 module.exports = AsciiPort;

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -3,40 +3,16 @@ var util = require('util');
 var events = require('events');
 var dgram = require('dgram');
 
+var crc16 = require('./../utils/crc16');
+
 var C701_PORT = 0x7002;
-
-/**
- * calculate crc16
- *
- * @param {buffer} buf the buffer to to crc on.
- * @return {number} the calculated crc16
- */
-function crc16(buf) {
-    var length = buf.length - 2;
-    var crc = 0xFFFF;
-    var tmp;
-
-    // calculate crc16
-    for (var i = 0; i < length; i++) {
-        crc = crc ^ buf[i];
-
-        for (var j = 0; j < 8; j++) {
-            tmp = crc & 0x0001;
-            crc = crc >> 1;
-            if (tmp) {
-              crc = crc ^ 0xA001;
-            }
-        }
-    }
-
-    return crc;
-}
 
 /**
  * check if a buffer chunk can be a modbus answer
  * or modbus exception
  *
- * @param {buffer} buf the buffer to check.
+ * @param {UdpPort} modbus
+ * @param {Buffer} buf the buffer to check.
  * @return {boolean} if the buffer can be an answer
  */
 function checkData(modbus, buf) {
@@ -94,12 +70,11 @@ var UdpPort = function(ip, options) {
         //check the serial data
         if (checkData(modbus, buffer)) {
             modbus.emit('data', buffer);
-            return;
         }
     });
 
     events.call(this);
-}
+};
 util.inherits(UdpPort, events);
 
 /**
@@ -108,7 +83,7 @@ util.inherits(UdpPort, events);
 UdpPort.prototype.open = function (callback) {
     if (callback)
         callback(null);
-}
+};
 
 /**
  * Simulate successful close port
@@ -117,7 +92,7 @@ UdpPort.prototype.close = function (callback) {
     this._client.close();
     if (callback)
         callback(null);
-}
+};
 
 /**
  * Send data to a modbus-tcp slave
@@ -171,6 +146,6 @@ UdpPort.prototype.write = function (data) {
 
     // send buffer to C701 UDP to serial bridge
     this._client.send(buffer, 0, buffer.length, this.port, this.ip);
-}
+};
 
 module.exports = UdpPort;

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -3,38 +3,14 @@ var util = require('util');
 var events = require('events');
 var SerialPort = require("serialport").SerialPort;
 
-/**
- * calculate crc16
- *
- * @param {buffer} buf the buffer to to crc on.
- * @return {number} the calculated crc16
- */
-function crc16(buf) {
-    var length = buf.length - 2;
-    var crc = 0xFFFF;
-    var tmp;
-
-    // calculate crc16
-    for (var i = 0; i < length; i++) {
-        crc = crc ^ buf[i];
-
-        for (var j = 0; j < 8; j++) {
-            tmp = crc & 0x0001;
-            crc = crc >> 1;
-            if (tmp) {
-              crc = crc ^ 0xA001;
-            }
-        }
-    }
-
-    return crc;
-}
+var crc16 = require('./../utils/crc16');
 
 /**
  * check if a buffer chunk can be a modbus answer
  * or modbus exception
  *
- * @param {buffer} buf the buffer to check.
+ * @param {RTUBufferedPort} modbus
+ * @param {Buffer} buf the buffer to check.
  * @return {boolean} if the buffer can be an answer
  */
 function checkData(modbus, buf) {
@@ -105,7 +81,7 @@ var RTUBufferedPort = function(path, options) {
     });
 
     events.call(this);
-}
+};
 util.inherits(RTUBufferedPort, events);
 
 /**
@@ -113,14 +89,15 @@ util.inherits(RTUBufferedPort, events);
  */
 RTUBufferedPort.prototype.open = function (callback) {
     this._client.open(callback);
-}
+};
 
 /**
  * Simulate successful close port
  */
 RTUBufferedPort.prototype.close = function (callback) {
     this._client.close(callback);
-}
+};
+
 /**
  * Send data to a modbus slave via telnet server
  */
@@ -161,6 +138,6 @@ RTUBufferedPort.prototype.write = function (data) {
 
     // send buffer to slave
     this._client.write(data);
-}
+};
 
 module.exports = RTUBufferedPort;

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -3,35 +3,9 @@ var util = require('util');
 var events = require('events');
 var net = require('net');
 
-var MODBUS_PORT = 502; // modbus port
+var crc16 = require('./../utils/crc16');
 
-/**
- * calculate crc16
- *
- * @param {buffer} buf the buffer to to crc on.
- *
- * @return {number} the calculated crc16
- */
-function crc16(buf) {
-    var length = buf.length - 2;
-    var crc = 0xFFFF;
-    var tmp;
-    
-    // calculate crc16
-    for (var i = 0; i < length; i++) {
-        crc = crc ^ buf[i];
-        
-        for (var j = 0; j < 8; j++) {
-            tmp = crc & 0x0001;
-            crc = crc >> 1;
-            if (tmp) {
-              crc = crc ^ 0xA001;
-            }
-        }
-    }
-    
-    return crc;
-}
+var MODBUS_PORT = 502; // modbus port
 
 /**
  * Simulate a modbus-RTU port using modbus-TCP connection
@@ -64,7 +38,7 @@ var TcpPort = function(ip, options) {
     });
 
     events.call(this);
-}
+};
 util.inherits(TcpPort, events);
 
 /**
@@ -72,7 +46,7 @@ util.inherits(TcpPort, events);
  */
 TcpPort.prototype.open = function (callback) {
     this._client.connect(this.port, this.ip, callback);
-}
+};
 
 /**
  * Simulate successful close port
@@ -81,7 +55,7 @@ TcpPort.prototype.close = function (callback) {
     this._client.end();
     if (callback)
         callback(null);
-}
+};
 
 /**
  * Send data to a modbus-tcp slave
@@ -96,6 +70,6 @@ TcpPort.prototype.write = function (data) {
     
     // send buffer to slave
     this._client.write(buffer);
-}
+};
 
 module.exports = TcpPort;

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -3,40 +3,16 @@ var util = require('util');
 var events = require('events');
 var net = require('net');
 
+var crc16 = require('./../utils/crc16');
+
 var TELNET_PORT = 2217;
-
-/**
- * calculate crc16
- *
- * @param {buffer} buf the buffer to to crc on.
- * @return {number} the calculated crc16
- */
-function crc16(buf) {
-    var length = buf.length - 2;
-    var crc = 0xFFFF;
-    var tmp;
-
-    // calculate crc16
-    for (var i = 0; i < length; i++) {
-        crc = crc ^ buf[i];
-
-        for (var j = 0; j < 8; j++) {
-            tmp = crc & 0x0001;
-            crc = crc >> 1;
-            if (tmp) {
-              crc = crc ^ 0xA001;
-            }
-        }
-    }
-
-    return crc;
-}
 
 /**
  * check if a buffer chunk can be a modbus answer
  * or modbus exception
  *
- * @param {buffer} buf the buffer to check.
+ * @param {TelnetPort} modbus
+ * @param {Buffer} buf the buffer to check.
  * @return {boolean} if the buffer can be an answer
  */
 function checkData(modbus, buf) {
@@ -109,7 +85,7 @@ var TelnetPort = function(ip, options) {
     });
 
     events.call(this);
-}
+};
 util.inherits(TelnetPort, events);
 
 /**
@@ -117,7 +93,7 @@ util.inherits(TelnetPort, events);
  */
 TelnetPort.prototype.open = function (callback) {
     this._client.connect(this.port, this.ip, callback);
-}
+};
 
 /**
  * Simulate successful close port
@@ -126,7 +102,7 @@ TelnetPort.prototype.close = function (callback) {
     this._client.end();
     if (callback)
         callback(null);
-}
+};
 
 /**
  * Send data to a modbus slave via telnet server
@@ -168,6 +144,6 @@ TelnetPort.prototype.write = function (data) {
 
     // send buffer to slave
     this._client.write(data);
-}
+};
 
 module.exports = TelnetPort;

--- a/utils/crc16.js
+++ b/utils/crc16.js
@@ -1,0 +1,25 @@
+'use strict';
+/**
+ * Calculates the buffers CRC16.
+ *
+ * @param {Buffer} buffer the data buffer.
+ * @return {number} the calculated CRC16.
+ */
+module.exports = function (buffer) {
+    var crc = 0xFFFF;
+    var tmp;
+
+    for (var i = 0; i < buffer.length; i++) {
+        crc = crc ^ buffer[i];
+
+        for (var j = 0; j < 8; j++) {
+            tmp = crc & 0x0001;
+            crc = crc >> 1;
+            if (tmp) {
+                crc = crc ^ 0xA001;
+            }
+        }
+    }
+
+    return crc;
+};


### PR DESCRIPTION
The crc16 function was duplicated all over the code, so I moved it to utils/crc16.

Additionally I fixed the JSDocs when built-in objects were referenced. Case sensitivity is of importance here to allow IDEs to resolve the type.