### PR TITLE
Add a check to see if the configured port is open before attempting a…

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,6 +295,13 @@ ModbusRTU.prototype.writeFC2 = function (address, dataAddress, length, next, cod
     // function code defaults to 2
     code = code || 2;
 
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
+
     // set state variables
     this._nextAddress = address;
     this._nextCode = code;
@@ -340,6 +347,13 @@ ModbusRTU.prototype.writeFC4 = function (address, dataAddress, length, next, cod
     // function code defaults to 4
     code = code || 4;
 
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
+
     // set state variables
     this._nextAddress = address;
     this._nextCode = code;
@@ -371,6 +385,13 @@ ModbusRTU.prototype.writeFC4 = function (address, dataAddress, length, next, cod
  */
 ModbusRTU.prototype.writeFC5 =  function (address, dataAddress, state, next) {
     var code = 5;
+
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
 
     // set state variables
     this._nextAddress = address;
@@ -409,6 +430,13 @@ ModbusRTU.prototype.writeFC5 =  function (address, dataAddress, state, next) {
 ModbusRTU.prototype.writeFC6 =  function (address, dataAddress, value, next) {
     var code = 6;
 
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
+
     // set state variables
     this._nextAddress = address;
     this._nextCode = code;
@@ -441,6 +469,13 @@ ModbusRTU.prototype.writeFC6 =  function (address, dataAddress, value, next) {
  */
 ModbusRTU.prototype.writeFC15 = function (address, dataAddress, array, next) {
     var code = 15;
+
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
 
     // set state variables
     this._nextAddress = address;
@@ -488,6 +523,13 @@ ModbusRTU.prototype.writeFC15 = function (address, dataAddress, array, next) {
  */
 ModbusRTU.prototype.writeFC16 =  function (address, dataAddress, array, next) {
     var code = 16;
+
+    // check port is actually open before attempting write
+    if( this._port.isOpen() === false) {
+        var error = "Port Not Open";
+        if (next) next(error);
+        return;
+    }
 
     // set state variables
     this._nextAddress = address;

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -176,7 +176,14 @@ AsciiPort.prototype.close = function (callback) {
 };
 
 /**
- * Send data to a modbus slave via telnet server
+ * Check if port is open
+ */
+AsciiPort.prototype.isOpen = function() {
+    return this._client.isOpen();
+};
+
+/**
+ * Send data to a modbus slave
  */
 AsciiPort.prototype.write = function (data) {
     // check data length

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -34,6 +34,7 @@ function checkData(modbus, buf) {
 var UdpPort = function(ip, options) {
     var modbus = this;
     this.ip = ip;
+    this.openFlag = false;
 
     // options
     if (typeof(options) == 'undefined') options = {};
@@ -73,6 +74,14 @@ var UdpPort = function(ip, options) {
         }
     });
 
+    this._client.on('listening', function() {
+        this.openFlag = true;
+    });
+
+    this._client.on('close', function(had_error) {
+        this.openFlag = false;
+    });
+
     events.call(this);
 };
 util.inherits(UdpPort, events);
@@ -92,6 +101,13 @@ UdpPort.prototype.close = function (callback) {
     this._client.close();
     if (callback)
         callback(null);
+};
+
+/**
+ * Check if port is open
+ */
+UdpPort.prototype.isOpen = function() {
+    return this.openFlag;
 };
 
 /**

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -99,7 +99,14 @@ RTUBufferedPort.prototype.close = function (callback) {
 };
 
 /**
- * Send data to a modbus slave via telnet server
+ * Check if port is open
+ */
+RTUBufferedPort.prototype.isOpen = function() {
+    return this._client.isOpen();
+};
+
+/**
+ * Send data to a modbus slave
  */
 RTUBufferedPort.prototype.write = function (data) {
     // check data length

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -34,6 +34,7 @@ function checkData(modbus, buf) {
 var TelnetPort = function(ip, options) {
     var modbus = this;
     this.ip = ip;
+    this.openFlag = false;
 
     // options
     if (typeof(options) == 'undefined') options = {};
@@ -84,6 +85,14 @@ var TelnetPort = function(ip, options) {
         }
     });
 
+    this._client.on('connect', function() {
+        this.openFlag = true;
+    });
+
+    this._client.on('close', function(had_error) {
+        this.openFlag = false;
+    });
+
     events.call(this);
 };
 util.inherits(TelnetPort, events);
@@ -102,6 +111,13 @@ TelnetPort.prototype.close = function (callback) {
     this._client.end();
     if (callback)
         callback(null);
+};
+
+/**
+ * Check if port is open
+ */
+TelnetPort.prototype.isOpen = function() {
+    return this.openFlag;
 };
 
 /**

--- a/ports/testport.js
+++ b/ports/testport.js
@@ -45,6 +45,13 @@ TestPort.prototype.close = function (callback) {
 };
 
 /**
+ * Check if port is open
+ */
+TestPort.prototype.isOpen = function() {
+    return true;
+};
+
+/**
  * Simulate successful/failure port requests and replays
  */
 TestPort.prototype.write = function (buf) {
@@ -180,7 +187,7 @@ TestPort.prototype.write = function (buf) {
         // write coils
         for (var i = 0; i < length; i++) {
             var state = buf.readBit(i, 7);
-            
+
             if (state) {
                 this._coils |= (1 << (address + i));
             } else {


### PR DESCRIPTION
To avoid any possibility of attempting a write on a non-open port I have added a test to check the port has been opened successfully.
With the serial ports there is a simple isOpen() method which I have tied into. With the other ports I have added a flag which is set/unset by the addition of .on('opened') and .on('closed') signals provided by the udp or tcp protocols.
Hope this makes sense.