### PR TITLE
fix isOpen method where extra flag is required to set connection state

### DIFF
--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -75,11 +75,11 @@ var UdpPort = function(ip, options) {
     });
 
     this._client.on('listening', function() {
-        this.openFlag = true;
+        modbus.openFlag = true;
     });
 
     this._client.on('close', function(had_error) {
-        this.openFlag = false;
+        modbus.openFlag = false;
     });
 
     events.call(this);

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -39,11 +39,11 @@ var TcpPort = function(ip, options) {
     });
 
     this._client.on('connect', function() {
-        this.openFlag = true;
+        _tcpport.openFlag = true;
     });
 
     this._client.on('close', function(had_error) {
-        this.openFlag = false;
+        _tcpport.openFlag = false;
     });
 
     events.call(this);

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -86,11 +86,11 @@ var TelnetPort = function(ip, options) {
     });
 
     this._client.on('connect', function() {
-        this.openFlag = true;
+        modbus.openFlag = true;
     });
 
     this._client.on('close', function(had_error) {
-        this.openFlag = false;
+        modbus.openFlag = false;
     });
 
     events.call(this);


### PR DESCRIPTION
I seem to have broken the ethernet based ports (telnet,tcp,c701) when I added the isOpen() method in.
When testing they respond as closed even when open as I had set the flag without the correct context pointer.
This has now been fixed, sorry for the trouble.