### PR TITLE
Make EventEmitter usage compatible with legacy NodeJS (0.10.x, 0.12.x)

### DIFF
--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var SerialPort = require("serialport").SerialPort;
 
 var crc16 = require('./../utils/crc16');
@@ -141,9 +142,9 @@ var AsciiPort = function(path, options) {
         }
     });
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(AsciiPort, events);
+util.inherits(AsciiPort, EventEmitter);
 
 /**
  * Simulate successful port open

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var dgram = require('dgram');
 
 var crc16 = require('./../utils/crc16');
@@ -82,9 +83,9 @@ var UdpPort = function(ip, options) {
         modbus.openFlag = false;
     });
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(UdpPort, events);
+util.inherits(UdpPort, EventEmitter);
 
 /**
  * Simulate successful port open

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var SerialPort = require("serialport").SerialPort;
 
 var EXCEPTION_LENGTH = 5;
@@ -54,9 +55,9 @@ var RTUBufferedPort = function(path, options) {
         }
     });
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(RTUBufferedPort, events);
+util.inherits(RTUBufferedPort, EventEmitter);
 
 /**
  * Emit the received response, cut the buffer and reset the internal vars.

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var net = require('net');
 
 var crc16 = require('./../utils/crc16');
@@ -63,9 +64,9 @@ var TcpPort = function(ip, options) {
         handleCallback(had_error);
     });
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(TcpPort, events);
+util.inherits(TcpPort, EventEmitter);
 
 /**
  * Simulate successful port open

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var net = require('net');
 
 var EXCEPTION_LENGTH = 5;
@@ -83,9 +84,9 @@ var TelnetPort = function(ip, options) {
         handleCallback(had_error);
     });
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(TelnetPort, events);
+util.inherits(TelnetPort, EventEmitter);
 
 /**
  * Emit the received response, cut the buffer and reset the internal vars.

--- a/ports/testport.js
+++ b/ports/testport.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 
 /* Add bit operation functions to Buffer
  */
@@ -25,9 +26,9 @@ var TestPort = function() {
     // simulate 16 coils / digital inputs
     this._coils = 0x0000; // TODO 0xa12b, 1010 0001 0010 1011
 
-    events.call(this);
+    EventEmitter.call(this);
 };
-util.inherits(TestPort, events);
+util.inherits(TestPort, EventEmitter);
 
 /**
  * Simulate successful port open

--- a/test/mocks/SerialPortMock.js
+++ b/test/mocks/SerialPortMock.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
-var EventEmitter = require('events');
+var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 
 
 /**

--- a/test/mocks/dgramMock.js
+++ b/test/mocks/dgramMock.js
@@ -1,5 +1,6 @@
 'use strict';
-var EventEmitter = require('events');
+var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var util = require('util');
 
 var Socket = function(type, listener) {

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -1,5 +1,6 @@
 'use strict';
-var EventEmitter = require('events');
+var events = require('events');
+var EventEmitter = events.EventEmitter || events;
 var util = require('util');
 
 var Server = function(options, connectionListener) {


### PR DESCRIPTION
Without this, you'll see this cryptic error:

ctor.prototype = Object.create(superCtor.prototype, {
                          ^
TypeError: Object prototype may only be an Object or null

Any time one requires this module. What changed after 0.12.x is that whereas before EventEmitter was a class within the event module, it has now been moved to the top level.