### PR TITLE
Add transaction dictionary, to replace the object current state vars.

### DIFF
--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -55,8 +55,8 @@ describe('Modbus TCP port', function() {
             port.open(function() {
                 port.write(new Buffer('1103006B00037687', 'hex'));
 
-                if (port._client._data.equals(new Buffer('0001000000061103006B0003', 'hex'))) {
-                    port._client.receive(new Buffer('000100000006110366778899', 'hex'));
+                if (port._client._data.equals(new Buffer('0000000000061103006B0003', 'hex'))) {
+                    port._client.receive(new Buffer('000000000006110366778899', 'hex'));
                 }
             });
         });
@@ -79,7 +79,7 @@ describe('Modbus TCP port', function() {
     describe('#write', function() {
         it('should write a valid TCP message to the port', function() {
             port.write(new Buffer('1103006B00037687', 'hex'));
-            expect(port._client._data.toString('hex')).to.equal('0001000000061103006b0003');
+            expect(port._client._data.toString('hex')).to.equal('0002000000061103006b0003');
         });
     });
 


### PR DESCRIPTION
Add transaction support for transaction id field in the ModbusTCP packet.

Issue: https://github.com/yaacov/node-modbus-serial/issues/31