### PR TITLE
Update to be compatible with v4 branch of node-serialport

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -37,10 +37,12 @@ var addConnctionAPI = function(Modbus) {
             next = options;
             options = {};
         }
+        // disable auto open, as we handle the open
+        options.autoOpen = false;
 
         // create the SerialPort
         var SerialPort = require("serialport").SerialPort;
-        this._port = new SerialPort(path, options, false);
+        this._port = new SerialPort(path, options);
 
         // open and call next
         this.open(next);

--- a/apis/connection.js
+++ b/apis/connection.js
@@ -41,7 +41,7 @@ var addConnctionAPI = function(Modbus) {
         options.autoOpen = false;
 
         // create the SerialPort
-        var SerialPort = require("serialport").SerialPort;
+        var SerialPort = require("serialport");
         this._port = new SerialPort(path, options);
 
         // open and call next

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -2,7 +2,7 @@
 var util = require('util');
 var events = require('events');
 var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport").SerialPort;
+var SerialPort = require("serialport");
 
 var crc16 = require('./../utils/crc16');
 var calculateLrc = require('./../utils/lrc');

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -90,6 +90,9 @@ var AsciiPort = function(path, options) {
     // options
     options = options || {};
 
+    // disable auto open, as we handle the open
+    options.autoOpen = false;
+
     // internal buffer
     this._buffer = new Buffer(0);
     this._id = 0;
@@ -97,7 +100,7 @@ var AsciiPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client= new SerialPort(path, options, false);
+    this._client= new SerialPort(path, options);
 
     // register the port data event
     this._client.on('data', function(data) {

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -15,6 +15,9 @@ var RTUBufferedPort = function(path, options) {
     // options
     if (typeof(options) == 'undefined') options = {};
 
+    // disable auto open, as we handle the open
+    options.autoOpen = false;
+
     // internal buffer
     this._buffer = new Buffer(0);
     this._id = 0;
@@ -22,7 +25,7 @@ var RTUBufferedPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client= new SerialPort(path, options, false);
+    this._client= new SerialPort(path, options);
 
     // register the port data event
     this._client.on('data', function onData(data) {

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -2,7 +2,7 @@
 var util = require('util');
 var events = require('events');
 var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport").SerialPort;
+var SerialPort = require("serialport");
 
 var EXCEPTION_LENGTH = 5;
 


### PR DESCRIPTION
As per the upgrade guide
https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/4.0.1/UPGRADE_GUIDE.md

1 deprecation and 1 breaking change (if running with autoconnect disabled as modbus is).

I have tested this with rtubuffered mode, and applied the change to rtu and ascii modes too
