### PR TITLE
return error objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ function _startTimeout(duration, next) {
     }
     return setTimeout(function () {
         if (next) {
-            next('Timed out');
+            next(new Error('Timed out'));
         }
     }, duration);
 }
@@ -220,7 +220,7 @@ ModbusRTU.prototype.open = function (callback) {
                     error = "Data length error, expected " +
                         transaction.nextLength + " got " + data.length;
                     if (transaction.next)
-                        transaction.next(error);
+                        transaction.next(new Error(error));
                     return;
                 }
 
@@ -231,7 +231,7 @@ ModbusRTU.prototype.open = function (callback) {
                 if (crcIn != crc16(data.slice(0, -2))) {
                     error = "CRC error";
                     if (transaction.next)
-                        transaction.next(error);
+                        transaction.next(new Error(error));
                     return;
                 }
 
@@ -245,7 +245,7 @@ ModbusRTU.prototype.open = function (callback) {
                     code == (0x80 | transaction.nextCode)) {
                     error = "Modbus exception " + data.readUInt8(2);
                     if (transaction.next)
-                        transaction.next(error);
+                        transaction.next(new Error(error));
                     return;
                 }
 
@@ -257,7 +257,7 @@ ModbusRTU.prototype.open = function (callback) {
                     error = "Data length error, expected " +
                         transaction.nextLength + " got " + data.length;
                     if (transaction.next)
-                        transaction.next(error);
+                        transaction.next(new Error(error));
                     return;
                 }
 
@@ -269,7 +269,7 @@ ModbusRTU.prototype.open = function (callback) {
                     error = "Unexpected data error, expected " +
                         transaction.nextAddress + " got " + address;
                     if (transaction.next)
-                        transaction.next(error);
+                        transaction.next(new Error(error));
                     return;
                 }
 
@@ -348,7 +348,7 @@ ModbusRTU.prototype.writeFC2 = function (address, dataAddress, length, next, cod
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
         var error = "Port Not Open";
-        if (next) next(error);
+        if (next) next(new Error(error));
         return;
     }
 
@@ -401,8 +401,10 @@ ModbusRTU.prototype.writeFC4 = function (address, dataAddress, length, next, cod
 
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        var error = "Port Not Open";
-        if (next) next(error);
+        if (next) {
+            var message = "Port Not Open";
+            next(new Error(message));
+        }
         return;
     }
 
@@ -442,8 +444,10 @@ ModbusRTU.prototype.writeFC5 = function (address, dataAddress, state, next) {
 
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        var error = "Port Not Open";
-        if (next) next(error);
+        if (next) {
+            var message = "Port Not Open";
+            next(new Error(message));
+        }
         return;
     }
 
@@ -488,8 +492,10 @@ ModbusRTU.prototype.writeFC6 = function (address, dataAddress, value, next) {
 
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        var error = "Port Not Open";
-        if (next) next(error);
+        if (next) {
+            var message = "Port Not Open";
+            next(new Error(message));
+        }
         return;
     }
 
@@ -586,8 +592,10 @@ ModbusRTU.prototype.writeFC16 = function (address, dataAddress, array, next) {
 
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        var error = "Port Not Open";
-        if (next) next(error);
+        if (next) {
+            var message = "Port Not Open";
+            next(new Error(message));
+        }
         return;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on short data answer', function (done) {
                 modbusRTU.writeFC3(2, 8, 3, function (err, data) {
-                    expect(err).to.have.string('Data length error');
+                    expect(err.message).to.have.string('Data length error');
 
                     done();
                 });
@@ -74,7 +74,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on CRC error', function (done) {
                 modbusRTU.writeFC3(3, 8, 3, function (err, data) {
-                    expect(err).to.have.string('CRC error');
+                    expect(err.message).to.have.string('CRC error');
 
                     done();
                 });
@@ -82,7 +82,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on unexpected reply', function (done) {
                 modbusRTU.writeFC3(4, 8, 3, function (err, data) {
-                    expect(err).to.have.string('Unexpected data error');
+                    expect(err.message).to.have.string('Unexpected data error');
 
                     done();
                 });
@@ -90,7 +90,7 @@ describe('ModbusRTU', function () {
 
             it('should fail with an exception', function (done) {
                 modbusRTU.writeFC3(5, 8, 3, function (err, data) {
-                    expect(err).to.have.string('Modbus exception');
+                    expect(err.message).to.have.string('Modbus exception');
 
                     done();
                 });
@@ -110,7 +110,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on short data answer', function (done) {
                 modbusRTU.writeFC4(2, 8, 1, function (err, data) {
-                    expect(err).to.have.string('Data length error');
+                    expect(err.message).to.have.string('Data length error');
 
                     done();
                 });
@@ -118,7 +118,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on CRC error', function (done) {
                 modbusRTU.writeFC4(3, 8, 1, function (err, data) {
-                    expect(err).to.have.string('CRC error');
+                    expect(err.message).to.have.string('CRC error');
 
                     done();
                 });
@@ -126,7 +126,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on unexpected reply', function (done) {
                 modbusRTU.writeFC4(4, 8, 1, function (err, data) {
-                    expect(err).to.have.string('Unexpected data error');
+                    expect(err.message).to.have.string('Unexpected data error');
 
                     done();
                 });
@@ -134,7 +134,7 @@ describe('ModbusRTU', function () {
 
             it('should fail with an exception', function (done) {
                 modbusRTU.writeFC4(5, 8, 3, function (err, data) {
-                    expect(err).to.have.string('Modbus exception');
+                    expect(err.message).to.have.string('Modbus exception');
 
                     done();
                 });
@@ -154,7 +154,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on short data answer', function (done) {
                 modbusRTU.writeFC6(2, 1, 42, function (err, data) {
-                    expect(err).to.have.string('Data length error');
+                    expect(err.message).to.have.string('Data length error');
 
                     done();
                 });
@@ -162,7 +162,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on CRC error', function (done) {
                 modbusRTU.writeFC6(3, 1, 42, function (err, data) {
-                    expect(err).to.have.string('CRC error');
+                    expect(err.message).to.have.string('CRC error');
 
                     done();
                 });
@@ -170,7 +170,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on unexpected reply', function (done) {
                 modbusRTU.writeFC6(4, 1, 42, function (err, data) {
-                    expect(err).to.have.string('Unexpected data error');
+                    expect(err.message).to.have.string('Unexpected data error');
 
                     done();
                 });
@@ -178,7 +178,7 @@ describe('ModbusRTU', function () {
 
             it('should fail with an exception', function (done) {
                 modbusRTU.writeFC6(5, 1, 42, function (err, data) {
-                    expect(err).to.have.string('Modbus exception');
+                    expect(err.message).to.have.string('Modbus exception');
 
                     done();
                 });
@@ -196,7 +196,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on short data answer', function (done) {
                 modbusRTU.writeFC15(2, 8, [true, false, true], function (err, data) {
-                    expect(err).to.have.string('Data length error');
+                    expect(err.message).to.have.string('Data length error');
 
                     done();
                 });
@@ -204,7 +204,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on CRC error', function (done) {
                 modbusRTU.writeFC15(3, 8, [true, false, true], function (err, data) {
-                    expect(err).to.have.string('CRC error');
+                    expect(err.message).to.have.string('CRC error');
 
                     done();
                 });
@@ -212,7 +212,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on unexpected reply', function (done) {
                 modbusRTU.writeFC15(4, 8, [true, false, true], function (err, data) {
-                    expect(err).to.have.string('Unexpected data error');
+                    expect(err.message).to.have.string('Unexpected data error');
 
                     done();
                 });
@@ -220,7 +220,7 @@ describe('ModbusRTU', function () {
 
             it('should fail with an exception', function (done) {
                 modbusRTU.writeFC15(5, 8, [true, false, true], function (err, data) {
-                    expect(err).to.have.string('Modbus exception');
+                    expect(err.message).to.have.string('Modbus exception');
 
                     done();
                 });
@@ -252,7 +252,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on short data answer', function (done) {
                 modbusRTU.writeFC16(2, 8, [42, 128, 5], function (err, data) {
-                    expect(err).to.have.string('Data length error');
+                    expect(err.message).to.have.string('Data length error');
 
                     done();
                 });
@@ -260,7 +260,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on CRC error', function (done) {
                 modbusRTU.writeFC16(3, 8, [42, 128, 5], function (err, data) {
-                    expect(err).to.have.string('CRC error');
+                    expect(err.message).to.have.string('CRC error');
 
                     done();
                 });
@@ -268,7 +268,7 @@ describe('ModbusRTU', function () {
 
             it('should fail on unexpected reply', function (done) {
                 modbusRTU.writeFC16(4, 8, [42, 128, 5], function (err, data) {
-                    expect(err).to.have.string('Unexpected data error');
+                    expect(err.message).to.have.string('Unexpected data error');
 
                     done();
                 });
@@ -276,7 +276,7 @@ describe('ModbusRTU', function () {
 
             it('should fail with an exception', function (done) {
                 modbusRTU.writeFC16(5, 8, [42, 128, 5], function (err, data) {
-                    expect(err).to.have.string('Modbus exception');
+                    expect(err.message).to.have.string('Modbus exception');
 
                     done();
                 });
@@ -347,7 +347,7 @@ describe('ModbusRTU', function () {
             it('should time out', function (done) {
                 modbusRTU._timeout = timeout;
                 modbusRTU.writeFC3(6, 8, 3, function (err, data) {
-                    expect(err).to.have.string('Timed out');
+                    expect(err.message).to.have.string('Timed out');
                     done();
                 });
 
@@ -363,7 +363,7 @@ describe('ModbusRTU', function () {
                             done(new Error('Call should timeout'));
                         })
                         .catch(function (err) {
-                            expect(err).to.have.string('Timed out');
+                            expect(err.message).to.have.string('Timed out');
                             done();
                         });
 


### PR DESCRIPTION
Return error objects on error instead of strings.

We currently return strings to indicate error, this is inconsistent with the tcp and serial open error messages, this will make the errors we return, Error objects.    

@connium this is a breaking change ( if someone check for the string error value ) please review.