### PR TITLE
Fix: Cannot find module 'serialport'

### DIFF
--- a/index.js
+++ b/index.js
@@ -641,7 +641,9 @@ require('./apis/promise')(ModbusRTU);
 // exports
 module.exports = ModbusRTU;
 module.exports.TestPort = require('./ports/testport');
-module.exports.RTUBufferedPort = require('./ports/rtubufferedport');
+try {
+    module.exports.RTUBufferedPort = require('./ports/rtubufferedport');
+} catch (err) {}
 module.exports.TcpPort = require('./ports/tcpport');
 module.exports.TelnetPort = require('./ports/telnetport');
 module.exports.C701Port = require('./ports/c701port');


### PR DESCRIPTION
when `serialport` module doesn't installed.