### PR TITLE
Fix transaction index for TCP

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -22,7 +22,6 @@ var TcpPort = function(ip, options) {
     this.ip = ip;
     this.openFlag = false;
     this.callback = null;
-    this._transactionId = 0;
 
     // options
     if (typeof(options) == 'undefined') options = {};

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -35,7 +35,6 @@ var TcpRTUBufferedPort = function(ip, options) {
     this._id = 0;
     this._cmd = 0;
     this._length = 0;
-    this._transactionId = 0;
 
     // handle callback - call a callback function only once, for the first event
     // it will triger

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -55,8 +55,8 @@ describe('Modbus TCP port', function() {
             port.open(function() {
                 port.write(new Buffer('1103006B00037687', 'hex'));
 
-                if (port._client._data.equals(new Buffer('0001000000061103006B0003', 'hex'))) {
-                    port._client.receive(new Buffer('000100000006110366778899', 'hex'));
+                if (port._client._data.equals(new Buffer('0000000000061103006B0003', 'hex'))) {
+                    port._client.receive(new Buffer('000000000006110366778899', 'hex'));
                 }
             });
         });
@@ -69,7 +69,7 @@ describe('Modbus TCP port', function() {
             port.open(function() {
                 port.write(new Buffer('1103006B00037687', 'hex'));
 
-                if (port._client._data.equals(new Buffer('0002000000061103006B0003', 'hex'))) {
+                if (port._client._data.equals(new Buffer('0001000000061103006B0003', 'hex'))) {
                     port._client.receive(new Buffer('000100000005118304', 'hex'));
                 }
             });


### PR DESCRIPTION
Fix transaction index for TCP

the `_transactionId` should be set only once in `index.js`

cc @biancode 