### PR TITLE
Cleanups after making serialport a requiremant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ try these options on npm install to build, if you have problems to install
 
     --unsafe-perm --build-from-source
 
-For use over serial port (ModbusRTU), also install node-serialport:
-
-    npm install serialport@4.0.7
-
 
 #### What can I do with this module ?
 

--- a/index.js
+++ b/index.js
@@ -629,9 +629,7 @@ require("./apis/promise")(ModbusRTU);
 // exports
 module.exports = ModbusRTU;
 module.exports.TestPort = require("./ports/testport");
-try {
-    module.exports.RTUBufferedPort = require("./ports/rtubufferedport");
-} catch (err) {}
+module.exports.RTUBufferedPort = require("./ports/rtubufferedport");
 module.exports.TcpPort = require("./ports/tcpport");
 module.exports.TcpRTUBufferedPort = require("./ports/tcprtubufferedport");
 module.exports.TelnetPort = require("./ports/telnetport");

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "debug": "^2.6.1",
-    "serialport": "4.0.7"
+    "serialport": "^4.0.7"
   }
 }


### PR DESCRIPTION
In https://github.com/yaacov/node-modbus-serial/pull/89 we made `serialport` a requirement, now we need to adapt the documentation and code to assume `serialport` is available.

cc @brandly 