### PR TITLE
Add an errno to port not open error

### DIFF
--- a/examples/logger.js
+++ b/examples/logger.js
@@ -4,22 +4,32 @@
 //var ModbusRTU = require("modbus-serial");
 var ModbusRTU = require("../index");
 var client = new ModbusRTU();
+var timeOutRef = null;
 
 var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED"];
 
 // open connection to a serial port
 //client.connectRTU("/dev/ttyUSB0", {baudrate: 9600})
-client.connectTCP("127.0.0.1", { port: 8502 })
-    .then(setClient)
-    .then(function() {
-        console.log("Connected"); })
-    .catch(function(e) {
-        if(e.errno) {
-            if(networkErrors.includes(e.errno)) {
-                console.log("we have to reconnect");
+function connect() {
+    client.connectTCP("127.0.0.1", { port: 8502 })
+        .then(setClient)
+        .then(function() {
+            console.log("Connected"); })
+        .catch(function(e) {
+            if(e.errno) {
+                if(networkErrors.includes(e.errno)) {
+                    console.log("we have to reconnect");
+
+                    // close port
+                    client.close();
+
+                    // clear last run and try to re-connect
+                    clearTimeout(timeOutRef);
+                    setTimeout(connect, 1000);
+                }
             }
-        }
-        console.log(e.message); });
+            console.log(e.message); });
+}
 
 function setClient() {
     // set the client's unit id
@@ -38,5 +48,8 @@ function run() {
             console.log("Receive:", d.data); })
         .catch(function(e) {
             console.log(e.message); })
-        .then(function() { setTimeout(run, 1000); });
+        .then(function() { timeOutRef = setTimeout(run, 1000); });
 }
+
+// connect and start logging
+connect();

--- a/index.js
+++ b/index.js
@@ -638,7 +638,9 @@ require("./apis/promise")(ModbusRTU);
 // exports
 module.exports = ModbusRTU;
 module.exports.TestPort = require("./ports/testport");
-module.exports.RTUBufferedPort = require("./ports/rtubufferedport");
+try {
+    module.exports.RTUBufferedPort = require("./ports/rtubufferedport");
+} catch (err) {}
 module.exports.TcpPort = require("./ports/tcpport");
 module.exports.TcpRTUBufferedPort = require("./ports/tcprtubufferedport");
 module.exports.TelnetPort = require("./ports/telnetport");

--- a/index.js
+++ b/index.js
@@ -22,6 +22,15 @@ var crc16 = require("./utils/crc16");
 var modbusSerialDebug = require("debug")("modbus-serial");
 
 var PORT_NOT_OPEN_MESSAGE = "Port Not Open";
+var PORT_NOT_OPEN_ERRNO = "ECONNREFUSED";
+
+var PortNotOpenError = function() {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = PORT_NOT_OPEN_MESSAGE;
+    this.errno = PORT_NOT_OPEN_ERRNO;
+};
+
 /**
  * @fileoverview ModbusRTU module, exports the ModbusRTU class.
  * this class makes ModbusRTU calls fun and easy.
@@ -350,7 +359,7 @@ ModbusRTU.prototype.writeFC1 = function(address, dataAddress, length, next) {
 ModbusRTU.prototype.writeFC2 = function(address, dataAddress, length, next, code) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 
@@ -403,7 +412,7 @@ ModbusRTU.prototype.writeFC3 = function(address, dataAddress, length, next) {
 ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 
@@ -444,7 +453,7 @@ ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code
 ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 
@@ -489,7 +498,7 @@ ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
 ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 
@@ -530,7 +539,7 @@ ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
 ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 
@@ -586,7 +595,7 @@ ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
 ModbusRTU.prototype.writeFC16 = function(address, dataAddress, array, next) {
     // check port is actually open before attempting write
     if (this._port.isOpen() === false) {
-        if (next) next(new Error(PORT_NOT_OPEN_MESSAGE));
+        if (next) next(new PortNotOpenError());
         return;
     }
 

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -69,13 +69,13 @@ var TcpPort = function(ip, options) {
 
     this._client.on("close", function(had_error) {
         modbus.openFlag = false;
-        modbusSerialDebug("TCP port: signal close" + had_error);
+        modbusSerialDebug("TCP port: signal close: " + had_error);
         handleCallback(had_error);
     });
 
     this._client.on("error", function(had_error) {
         modbus.openFlag = false;
-        modbusSerialDebug("TCP port: signal error" + had_error);
+        modbusSerialDebug("TCP port: signal error: " + had_error);
         handleCallback(had_error);
     });
 


### PR DESCRIPTION
**Description**
Add an errno to the error emitted when trying to send a modbus commad on a closed port.

Change the logger.js example to use the new errno.