### PR TITLE
Fix wrong check for port open

### DIFF
--- a/examples/logger.js
+++ b/examples/logger.js
@@ -4,6 +4,7 @@
 //var ModbusRTU = require("modbus-serial");
 var ModbusRTU = require("../index");
 var client = new ModbusRTU();
+var timeoutRef = null;
 
 var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED"];
 
@@ -11,6 +12,9 @@ var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED
 function checkError(e) {
     if(e.errno && networkErrors.includes(e.errno)) {
         console.log("we have to reconnect");
+
+        // stop reading loop
+        clearTimeout(timeoutRef);
 
         // close port
         client.close();
@@ -51,7 +55,7 @@ function run() {
         .catch(function(e) {
             checkError(e);
             console.log(e.message); })
-        .then(function() { setTimeout(run, 1000); });
+        .then(function() { timeoutRef = setTimeout(run, 1000); });
 }
 
 // connect and start logging

--- a/index.js
+++ b/index.js
@@ -324,16 +324,22 @@ ModbusRTU.prototype.open = function(callback) {
  *      or failure.
  */
 ModbusRTU.prototype.close = function(callback) {
-    // close the serial port
-    this._port.close(callback);
-    this._port.removeAllListeners("data");
+    // close the serial port if exist
+    if (this._port) {
+        this._port.close(callback);
+        this._port.removeAllListeners("data");
+    }
 };
 
 /**
  * Check if port is open
  */
 ModbusRTU.prototype.isOpen = function() {
-    return this._port && this._port.isOpen();
+    if (this._port) {
+        return this._port.isOpen();
+    }
+
+    return false;
 };
 
 /**
@@ -358,7 +364,7 @@ ModbusRTU.prototype.writeFC1 = function(address, dataAddress, length, next) {
  */
 ModbusRTU.prototype.writeFC2 = function(address, dataAddress, length, next, code) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }
@@ -411,7 +417,7 @@ ModbusRTU.prototype.writeFC3 = function(address, dataAddress, length, next) {
  */
 ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }
@@ -452,7 +458,7 @@ ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code
  */
 ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }
@@ -497,7 +503,7 @@ ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
  */
 ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }
@@ -538,7 +544,7 @@ ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
  */
 ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }
@@ -594,7 +600,7 @@ ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
  */
 ModbusRTU.prototype.writeFC16 = function(address, dataAddress, array, next) {
     // check port is actually open before attempting write
-    if (this._port.isOpen() === false) {
+    if (this.isOpen() !== true) {
         if (next) next(new PortNotOpenError());
         return;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus-serial",
-  "version": "5.2.4",
+  "version": "5.2.6",
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Description**
While testing #93 found that we were not testing correctly for port open status, the isOpen function may have returned a none boolean, and checking with `=== false` will give false true.

a. make the isOpen return a boolean always.
b. fix the checks to avoid ambiguousness of false/true values. 