### PR TITLE
the serial ascii connect method should return a promise

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -202,7 +202,7 @@ var addConnctionAPI = function(Modbus) {
         this._port = new SerialPortAscii(path, options);
 
         // open and call next
-        open(this, next);
+        return open(this, next);
     };
 };
 


### PR DESCRIPTION
like all other connects the ascii connect should return a promise.
(Actually Node Red uses this prmise, and hence fails to open ascii
serial connection)