### PR TITLE
Moved .open() down to avoid callback before transactionId’s are set.

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,9 +203,6 @@ ModbusRTU.prototype.open = function(callback) {
             if (callback)
                 callback(error);
         } else {
-            /* On serial port open OK call next function */
-            if (callback)
-                callback(error);
 
             /* init ports transaction id and counter */
             modbus._port._transactionIdRead = 1;
@@ -321,6 +318,10 @@ ModbusRTU.prototype.open = function(callback) {
                         break;
                 }
             });
+
+            /* On serial port open OK call next function */
+            if (callback)
+                callback(error);
         }
     });
 };


### PR DESCRIPTION
Hello!

I had a timing-issue with your library.
When reading holding registers right after the open-callback of a RTU-serial connection, the read callback wanted to access the transaction callback before the transaction id's are set.

```
            modbus._port.on("data", function(data) {
                // set locale helpers variables
                var transaction = modbus._transactions[modbus._port._transactionIdRead];
                // --> TRANSACTION WAS UNDEFINED HERE...

                // the _transactionIdRead can be missing, ignore wrong transaction it's
                if (!transaction) {
                    return;
               }
```

Using the debugger, i was able to reproduce the issue step-by-step. A simple setTimeout solved the problem in the outer code.
I think it's better to fire the port.open()-callback later, when the id's are set and the events are attached. This little change solved the issue in my case.

System: OSX 10.12.4, node 6.9.1, ftdi-based usb-serial converter.

Best,
- Silvan