### PR TITLE
Change boudrate to baudRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ var ModbusRTU = require("modbus-serial");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-client.connectRTU("/dev/ttyUSB0", { baudrate: 9600 }, write);
+client.connectRTU("/dev/ttyUSB0", { baudRate: 9600 }, write);
 
 function write() {
     client.setID(1);
@@ -116,7 +116,7 @@ var ModbusRTU = require("modbus-serial");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-client.connectRTUBuffered("/dev/ttyUSB0", { baudrate: 9600 });
+client.connectRTUBuffered("/dev/ttyUSB0", { baudRate: 9600 });
 client.setID(1);
 
 // read the values of 10 registers starting at address 0

--- a/examples/buffer.js
+++ b/examples/buffer.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudrate: 9600})
+//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/debug.js
+++ b/examples/debug.js
@@ -15,7 +15,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudrate: 9600})
+//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -8,7 +8,7 @@ var client = new ModbusRTU();
 var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED"];
 
 // open connection to a serial port
-client.connectRTU("/dev/ttyUSB0", { baudrate: 115200 })
+client.connectRTU("/dev/ttyUSB0", { baudRate: 115200 })
 //client.connectTCP("modbus.local", { port: 502 })
     .then(setClient)
     .then(function() {

--- a/examples/write.js
+++ b/examples/write.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudrate: 9600})
+//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/write_complete.js
+++ b/examples/write_complete.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-// client.connectRTU("/dev/ttyUSB0", {baudrate: 9600})
+// client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {


### PR DESCRIPTION
**Description**

`node-modbus-serial` uses `node-serialport` `openOptions` [1] as options for creating and opening the modbus serial connection object.

In our examples in documentation we use a `baudrate` parameter that does not exist in `node-serialport` `openOptions`.

Issue: https://github.com/yaacov/node-modbus-serial/issues/152

Thanks @neldefant

[1] https://github.com/EmergingTechnologyAdvisors/node-serialport#module_serialport--SerialPort..openOptions