### PR TITLE
Using backword incompatible serial port, bumping major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus-serial",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since #155 we are using a none backward compatible serialport version.

No change to api, but this is none backward compatible change for users who relay on changed serialport functionality.