### PR TITLE
bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus-serial",
-  "version": "7.1.5",
+  "version": "7.2.0",
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Backward compatible changes:
  - Use serial port v6.1.1
  - Adding timeout to tcp connect 

Bug fixes:
  - Fix erros may be longer the 5 bytes 