### PR TITLE
adding destroy functions to each net.Socket ports

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,6 +375,20 @@ ModbusRTU.prototype.close = function(callback) {
 };
 
 /**
+ * Destory the serial port
+ *
+ * @param {Function} callback the function to call next on close success
+ *      or failure.
+ */
+ModbusRTU.prototype.destroy = function(callback) {
+    // close the serial port if exist and it has a destroy function
+    if (this._port && this._port.destroy) {
+        this._port.removeAllListeners("data");
+        this._port.destroy(callback);
+    }
+};
+
+/**
  * Write a Modbus "Read Coil Status" (FC=01) to serial port.
  *
  * @param {number} address the slave unit address.

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -138,6 +138,18 @@ TcpPort.prototype.close = function(callback) {
 };
 
 /**
+ * Simulate successful destroy port.
+ *
+ * @param callback
+ */
+TcpPort.prototype.destroy = function(callback) {
+    this.callback = callback;
+    if (!this._client.destroyed) {
+        this._client.destroy();
+    }
+};
+
+/**
  * Send data to a modbus-tcp slave.
  *
  * @param data

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -199,6 +199,18 @@ TcpRTUBufferedPort.prototype.close = function(callback) {
 };
 
 /**
+ * Simulate successful destroy port.
+ *
+ * @param callback
+ */
+TcpRTUBufferedPort.prototype.destroy = function(callback) {
+    this.callback = callback;
+    if (!this._client.destroyed) {
+        this._client.destroy();
+    }
+};
+
+/**
  * Send data to a modbus slave via telnet server.
  *
  * @param {Buffer} data

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -181,6 +181,18 @@ TelnetPort.prototype.close = function(callback) {
 };
 
 /**
+ * Simulate successful destroy port.
+ *
+ * @param callback
+ */
+TelnetPort.prototype.destroy = function(callback) {
+    this.callback = callback;
+    if (!this._client.destroyed) {
+        this._client.destroy();
+    }
+};
+
+/**
  * Send data to a modbus slave via telnet server.
  *
  * @param {Buffer} data

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -5,6 +5,7 @@ var util = require("util");
 
 var Socket = function() {
     EventEmitter.call(this);
+    this.destroyed = false;
 };
 util.inherits(Socket, EventEmitter);
 
@@ -25,6 +26,11 @@ Socket.prototype.write = function(data) {
 
 Socket.prototype.receive = function(buffer) {
     this.emit("data", buffer);
+};
+
+Socket.prototype.destroy = function() {
+    this.emit("close", true);
+    this.destroyed = true;
 };
 
 exports.Socket = Socket;

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -46,6 +46,16 @@ describe("Modbus TCP port", function() {
                 });
             });
         });
+        it("should be able to be destoryed after opening", function(done) {
+            port.open(function() {
+                port.destroy(function() {
+                    setTimeout(function() {
+                        expect(port.isOpen).to.be.false;
+                        done();
+                    });
+                });
+            });
+        });
     });
 
     describe("data handler", function() {

--- a/test/ports/tcpportrtubuffered.test.js
+++ b/test/ports/tcpportrtubuffered.test.js
@@ -49,6 +49,16 @@ describe("Modbus TCP RTU buffered port", function() {
                 });
             });
         });
+        it("should be able to be destoryed after opening", function(done) {
+            port.open(function() {
+                port.destroy(function() {
+                    setTimeout(function() {
+                        expect(port.isOpen).to.be.false;
+                        done();
+                    });
+                });
+            });
+        });
     });
 
     describe("data handler", function() {

--- a/test/ports/telnetport.test.js
+++ b/test/ports/telnetport.test.js
@@ -49,6 +49,16 @@ describe("Modbus Telnet port", function() {
                 });
             });
         });
+        it("should be able to be destoryed after opening", function(done) {
+            port.open(function() {
+                port.destroy(function() {
+                    setTimeout(function() {
+                        expect(port.isOpen).to.be.false;
+                        done();
+                    });
+                });
+            });
+        });
     });
 
     describe("data handler", function() {


### PR DESCRIPTION
After testing the timeouts further, I noticed that if you got the timeout signal the socket will continue trying to connect, because calling `socket.end` only half closes the socket trying to send a `fin` packet. However calling destroy kills the socket completely. I looked through the serial-ports docs and did not find an a destory function. 