### PR TITLE
Replace new Buffer with Buffer.alloc

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -8,7 +8,7 @@ var client = new ModbusRTU();
 var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
 
 // open connection to a serial port
-client.connectRTU("/dev/ttyUSB2")
+client.connectRTU("/dev/ttyUSB0", { hupcl: false, dsrdtr: false })
 //client.connectTCP("modbus.local", { port: 502 })
     .then(setClient)
     .then(function() {

--- a/index.js
+++ b/index.js
@@ -433,7 +433,7 @@ ModbusRTU.prototype.writeFC2 = function(address, dataAddress, length, next, code
     };
 
     var codeLength = 6;
-    var buf = new Buffer(codeLength + 2); // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);
@@ -492,7 +492,7 @@ ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code
     };
 
     var codeLength = 6;
-    var buf = new Buffer(codeLength + 2); // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);
@@ -538,7 +538,7 @@ ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
     };
 
     var codeLength = 6;
-    var buf = new Buffer(codeLength + 2); // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);
@@ -589,7 +589,7 @@ ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
     };
 
     var codeLength = 6; // 1B deviceAddress + 1B functionCode + 2B dataAddress + 2B value
-    var buf = new Buffer(codeLength + 2); // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);
@@ -638,7 +638,7 @@ ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
 
     var dataBytes = Math.ceil(array.length / 8);
     var codeLength = 7 + dataBytes;
-    var buf = new Buffer(codeLength + 2);  // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2);  // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);
@@ -698,7 +698,7 @@ ModbusRTU.prototype.writeFC16 = function(address, dataAddress, array, next) {
     };
 
     var codeLength = 7 + 2 * array.length;
-    var buf = new Buffer(codeLength + 2); // add 2 crc bytes
+    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
     buf.writeUInt8(address, 0);
     buf.writeUInt8(code, 1);

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -25,7 +25,7 @@ function _asciiEncodeRequestBuffer(buf) {
     buf.writeUInt8(calculateLrc(buf.slice(0, -2)), buf.length - 2);
 
     // create a new buffer of the correct size
-    var bufAscii = new Buffer(buf.length * 2 + 1); // 1 byte start delimit + x2 data as ascii encoded + 2 lrc + 2 end delimit
+    var bufAscii = Buffer.alloc(buf.length * 2 + 1); // 1 byte start delimit + x2 data as ascii encoded + 2 lrc + 2 end delimit
 
     // create the ascii payload
 
@@ -50,7 +50,7 @@ function _asciiEncodeRequestBuffer(buf) {
 function _asciiDecodeResponseBuffer(bufAscii) {
 
     // create a new buffer of the correct size (based on ascii encoded buffer length)
-    var bufDecoded = new Buffer((bufAscii.length - 1) / 2);
+    var bufDecoded = Buffer.alloc((bufAscii.length - 1) / 2);
 
     // decode into new buffer (removing delimiters at start and end)
     for (var i = 0; i < (bufAscii.length - 3) / 2; i++) {
@@ -112,7 +112,7 @@ var AsciiPort = function(path, options) {
     options.autoOpen = false;
 
     // internal buffer
-    this._buffer = new Buffer(0);
+    this._buffer = Buffer.from("");
     this._id = 0;
     this._cmd = 0;
     this._length = 0;
@@ -133,7 +133,7 @@ var AsciiPort = function(path, options) {
         var sdIndex = modbus._buffer.indexOf(0x3A); // ascii for ':'
         if(sdIndex === -1) {
             // if not there, reset the buffer and return
-            modbus._buffer = new Buffer(0);
+            modbus._buffer = Buffer.from("");
             return;
         }
         // if there is data before the start delimiter, remove it
@@ -163,7 +163,7 @@ var AsciiPort = function(path, options) {
                 }
             }
             // reset the buffer now its been used
-            modbus._buffer = new Buffer(0);
+            modbus._buffer = Buffer.from("");
         } else {
             // otherwise just wait for more data to arrive
         }

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -183,7 +183,7 @@ UdpPort.prototype.write = function(data) {
     }
 
     // build C701 header
-    var buffer = new Buffer(data.length + 116);
+    var buffer = Buffer.alloc(data.length + 116);
     buffer.fill(0);
     buffer.writeUInt16LE(600, 2);           // C701 magic for serial bridge
     buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -27,7 +27,7 @@ var RTUBufferedPort = function(path, options) {
     options.autoOpen = false;
 
     // internal buffer
-    this._buffer = new Buffer(0);
+    this._buffer = Buffer.alloc(0);
     this._id = 0;
     this._cmd = 0;
     this._length = 0;

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -58,7 +58,7 @@ var TcpPort = function(ip, options) {
             length = data.readUInt16BE(4);
 
             // cut 6 bytes of mbap and copy pdu
-            buffer = new Buffer(length + CRC_LENGTH);
+            buffer = Buffer.alloc(length + CRC_LENGTH);
             data.copy(buffer, 0, MIN_MBAP_LENGTH);
 
             // add crc to message
@@ -165,7 +165,7 @@ TcpPort.prototype.write = function(data) {
     this._cmd = data[1];
 
     // remove crc and add mbap
-    var buffer = new Buffer(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+    var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
     buffer.writeUInt16BE(this._transactionIdWrite, 0);
     buffer.writeUInt16BE(0, 2);
     buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -37,7 +37,7 @@ var TcpRTUBufferedPort = function(ip, options) {
     modbus.port = options.port || MODBUS_PORT;
 
     // internal buffer
-    modbus._buffer = new Buffer(0);
+    modbus._buffer = Buffer.alloc(0);
 
     // handle callback - call a callback function only once, for the first event
     // it will triger
@@ -225,7 +225,7 @@ TcpRTUBufferedPort.prototype.write = function(data) {
     }
 
     // remove crc and add mbap
-    var buffer = new Buffer(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+    var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
     buffer.writeUInt16BE(this._transactionIdWrite, 0);
     buffer.writeUInt16BE(0, 2);
     buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -29,7 +29,7 @@ var TelnetPort = function(ip, options) {
     this.port = options.port || TELNET_PORT; // telnet server port
 
     // internal buffer
-    this._buffer = new Buffer(0);
+    this._buffer = Buffer.alloc(0);
     this._id = 0;
     this._cmd = 0;
     this._length = 0;

--- a/ports/testport.js
+++ b/ports/testport.js
@@ -105,7 +105,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(3 + parseInt((length - 1) / 8 + 1) + 2);
+        buffer = Buffer.alloc(3 + parseInt((length - 1) / 8 + 1) + 2);
         buffer.writeUInt8(parseInt((length - 1) / 8 + 1), 2);
 
         // read coils
@@ -123,7 +123,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(3 + length * 2 + 2);
+        buffer = Buffer.alloc(3 + length * 2 + 2);
         buffer.writeUInt8(length * 2, 2);
 
         // read registers
@@ -143,7 +143,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(3 + length * 2 + 2);
+        buffer = Buffer.alloc(3 + length * 2 + 2);
         buffer.writeUInt8(length * 2, 2);
 
         // read registers
@@ -163,7 +163,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(8);
+        buffer = Buffer.alloc(8);
         buffer.writeUInt16BE(address, 2);
         buffer.writeUInt16BE(state, 4);
 
@@ -185,7 +185,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(8);
+        buffer = Buffer.alloc(8);
         buffer.writeUInt16BE(address, 2);
         buffer.writeUInt16BE(value, 4);
 
@@ -203,7 +203,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(8);
+        buffer = Buffer.alloc(8);
         buffer.writeUInt16BE(address, 2);
         buffer.writeUInt16BE(length, 4);
 
@@ -230,7 +230,7 @@ TestPort.prototype.write = function(data) {
         }
 
         // build answer
-        buffer = new Buffer(8);
+        buffer = Buffer.alloc(8);
         buffer.writeUInt16BE(address, 2);
         buffer.writeUInt16BE(length, 4);
 

--- a/test/ports/asciiport.test.js
+++ b/test/ports/asciiport.test.js
@@ -58,20 +58,20 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer(":", "ascii"));
-                    port._client.receive(new Buffer("11", "ascii"));
-                    port._client.receive(new Buffer("03", "ascii"));
-                    port._client.receive(new Buffer("06", "ascii"));
-                    port._client.receive(new Buffer("AE", "ascii"));
-                    port._client.receive(new Buffer("41", "ascii"));
-                    port._client.receive(new Buffer("56", "ascii"));
-                    port._client.receive(new Buffer("52", "ascii"));
-                    port._client.receive(new Buffer("43", "ascii"));
-                    port._client.receive(new Buffer("40", "ascii"));
-                    port._client.receive(new Buffer("CC", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
+                    port._client.receive(Buffer.from(":", "ascii"));
+                    port._client.receive(Buffer.from("11", "ascii"));
+                    port._client.receive(Buffer.from("03", "ascii"));
+                    port._client.receive(Buffer.from("06", "ascii"));
+                    port._client.receive(Buffer.from("AE", "ascii"));
+                    port._client.receive(Buffer.from("41", "ascii"));
+                    port._client.receive(Buffer.from("56", "ascii"));
+                    port._client.receive(Buffer.from("52", "ascii"));
+                    port._client.receive(Buffer.from("43", "ascii"));
+                    port._client.receive(Buffer.from("40", "ascii"));
+                    port._client.receive(Buffer.from("CC", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
                 });
             });
         });
@@ -82,14 +82,14 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer(":", "ascii"));
-                    port._client.receive(new Buffer("11", "ascii"));
-                    port._client.receive(new Buffer("83", "ascii"));
-                    port._client.receive(new Buffer("04", "ascii"));
-                    port._client.receive(new Buffer("68", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
+                    port._client.receive(Buffer.from(":", "ascii"));
+                    port._client.receive(Buffer.from("11", "ascii"));
+                    port._client.receive(Buffer.from("83", "ascii"));
+                    port._client.receive(Buffer.from("04", "ascii"));
+                    port._client.receive(Buffer.from("68", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
                 });
             });
         });
@@ -100,14 +100,14 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("010300000040443A", "hex"));
+                port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer(":", "ascii"));
+                    port._client.receive(Buffer.from(":", "ascii"));
                     for (var i = 0; i < (LONG_MSG.length - 4); i += 2) {
-                        port._client.receive(new Buffer(LONG_MSG.slice(i, i + 2), "ascii"));
+                        port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "ascii"));
                     }
-                    port._client.receive(new Buffer("7C", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
+                    port._client.receive(Buffer.from("7C", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
                 });
             });
         });
@@ -118,24 +118,24 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("20", "ascii")); // illegal char
-                    port._client.receive(new Buffer("54", "ascii")); // illegal char
-                    port._client.receive(new Buffer("54", "ascii")); // illegal char
-                    port._client.receive(new Buffer("FF", "ascii")); // illegal char
-                    port._client.receive(new Buffer(":", "ascii"));
-                    port._client.receive(new Buffer("11", "ascii"));
-                    port._client.receive(new Buffer("03", "ascii"));
-                    port._client.receive(new Buffer("06", "ascii"));
-                    port._client.receive(new Buffer("AE", "ascii"));
-                    port._client.receive(new Buffer("41", "ascii"));
-                    port._client.receive(new Buffer("56", "ascii"));
-                    port._client.receive(new Buffer("52", "ascii"));
-                    port._client.receive(new Buffer("43", "ascii"));
-                    port._client.receive(new Buffer("40", "ascii"));
-                    port._client.receive(new Buffer("CC", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
+                    port._client.receive(Buffer.from("20", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("54", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("54", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("FF", "ascii")); // illegal char
+                    port._client.receive(Buffer.from(":", "ascii"));
+                    port._client.receive(Buffer.from("11", "ascii"));
+                    port._client.receive(Buffer.from("03", "ascii"));
+                    port._client.receive(Buffer.from("06", "ascii"));
+                    port._client.receive(Buffer.from("AE", "ascii"));
+                    port._client.receive(Buffer.from("41", "ascii"));
+                    port._client.receive(Buffer.from("56", "ascii"));
+                    port._client.receive(Buffer.from("52", "ascii"));
+                    port._client.receive(Buffer.from("43", "ascii"));
+                    port._client.receive(Buffer.from("40", "ascii"));
+                    port._client.receive(Buffer.from("CC", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
                 });
             });
         });
@@ -146,24 +146,24 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer(":", "ascii"));
-                    port._client.receive(new Buffer("11", "ascii"));
-                    port._client.receive(new Buffer("03", "ascii"));
-                    port._client.receive(new Buffer("06", "ascii"));
-                    port._client.receive(new Buffer("AE", "ascii"));
-                    port._client.receive(new Buffer("41", "ascii"));
-                    port._client.receive(new Buffer("56", "ascii"));
-                    port._client.receive(new Buffer("52", "ascii"));
-                    port._client.receive(new Buffer("43", "ascii"));
-                    port._client.receive(new Buffer("40", "ascii"));
-                    port._client.receive(new Buffer("CC", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
-                    port._client.receive(new Buffer("20", "ascii")); // illegal char
-                    port._client.receive(new Buffer("54", "ascii")); // illegal char
-                    port._client.receive(new Buffer("54", "ascii")); // illegal char
-                    port._client.receive(new Buffer("FF", "ascii")); // illegal char
+                    port._client.receive(Buffer.from(":", "ascii"));
+                    port._client.receive(Buffer.from("11", "ascii"));
+                    port._client.receive(Buffer.from("03", "ascii"));
+                    port._client.receive(Buffer.from("06", "ascii"));
+                    port._client.receive(Buffer.from("AE", "ascii"));
+                    port._client.receive(Buffer.from("41", "ascii"));
+                    port._client.receive(Buffer.from("56", "ascii"));
+                    port._client.receive(Buffer.from("52", "ascii"));
+                    port._client.receive(Buffer.from("43", "ascii"));
+                    port._client.receive(Buffer.from("40", "ascii"));
+                    port._client.receive(Buffer.from("CC", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
+                    port._client.receive(Buffer.from("20", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("54", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("54", "ascii")); // illegal char
+                    port._client.receive(Buffer.from("FF", "ascii")); // illegal char
                 });
             });
         });
@@ -174,20 +174,20 @@ describe("Modbus Ascii port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer(":", "ascii"));
-                    port._client.receive(new Buffer("11", "ascii"));
-                    port._client.receive(new Buffer("03", "ascii"));
-                    port._client.receive(new Buffer("06", "ascii"));
-                    port._client.receive(new Buffer("AE", "ascii"));
-                    port._client.receive(new Buffer("41", "ascii"));
-                    port._client.receive(new Buffer("56", "ascii"));
-                    port._client.receive(new Buffer("52", "ascii"));
-                    port._client.receive(new Buffer("43", "ascii"));
-                    port._client.receive(new Buffer("40", "ascii"));
-                    port._client.receive(new Buffer("CC", "ascii"));
-                    port._client.receive(new Buffer("\r\n", "ascii"));
+                    port._client.receive(Buffer.from(":", "ascii"));
+                    port._client.receive(Buffer.from("11", "ascii"));
+                    port._client.receive(Buffer.from("03", "ascii"));
+                    port._client.receive(Buffer.from("06", "ascii"));
+                    port._client.receive(Buffer.from("AE", "ascii"));
+                    port._client.receive(Buffer.from("41", "ascii"));
+                    port._client.receive(Buffer.from("56", "ascii"));
+                    port._client.receive(Buffer.from("52", "ascii"));
+                    port._client.receive(Buffer.from("43", "ascii"));
+                    port._client.receive(Buffer.from("40", "ascii"));
+                    port._client.receive(Buffer.from("CC", "ascii"));
+                    port._client.receive(Buffer.from("\r\n", "ascii"));
                 });
             });
         });
@@ -195,7 +195,7 @@ describe("Modbus Ascii port", function() {
 
     describe("#write", function() {
         it("should write a valid RTU message to the port", function() {
-            port.write(new Buffer("1103006B00037687", "hex"));
+            port.write(Buffer.from("1103006B00037687", "hex"));
             expect(port._client._data.toString("ascii")).to.equal(":1103006B00037E\r\n");
         });
     });

--- a/test/ports/c701port.test.js
+++ b/test/ports/c701port.test.js
@@ -55,10 +55,10 @@ describe("Modbus UDP port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
 
-                if (port._client._data.slice(-8).equals(new Buffer("1103006B00037687", "hex"))) {
-                    var buffer = new Buffer(116 + 11).fill(0);
+                if (port._client._data.slice(-8).equals(Buffer.from("1103006B00037687", "hex"))) {
+                    var buffer = Buffer.alloc(116 + 11).fill(0);
                     buffer.writeUInt16LE(602, 2);           // C701 magic for serial bridge
                     buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
                     buffer.writeUInt16LE(0, 38);            // expected serial answer length
@@ -66,7 +66,7 @@ describe("Modbus UDP port", function() {
                     buffer.writeUInt16LE(11, 104);          // serial data length
 
                     // add serial line data
-                    new Buffer("110306ae415652434049ad", "hex").copy(buffer, 116);
+                    Buffer.from("110306ae415652434049ad", "hex").copy(buffer, 116);
                     port._client.receive(buffer);
                 }
             });
@@ -78,10 +78,10 @@ describe("Modbus UDP port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
 
-                if (port._client._data.slice(-8).equals(new Buffer("1103006B00037687", "hex"))) {
-                    var buffer = new Buffer(116 + 5).fill(0);
+                if (port._client._data.slice(-8).equals(Buffer.from("1103006B00037687", "hex"))) {
+                    var buffer = Buffer.alloc(116 + 5).fill(0);
                     buffer.writeUInt16LE(602, 2);           // C701 magic for serial bridge
                     buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
                     buffer.writeUInt16LE(0, 38);            // expected serial answer length
@@ -89,7 +89,7 @@ describe("Modbus UDP port", function() {
                     buffer.writeUInt16LE(11, 104);          // serial data length
 
                     // add serial line data
-                    new Buffer("1183044136", "hex").copy(buffer, 116);
+                    Buffer.from("1183044136", "hex").copy(buffer, 116);
                     port._client.receive(buffer);
                 }
             });
@@ -98,7 +98,7 @@ describe("Modbus UDP port", function() {
 
     describe("#write", function() {
         it("should write a valid message to the port", function() {
-            port.write(new Buffer("1103006B00037687", "hex"));
+            port.write(Buffer.from("1103006B00037687", "hex"));
             expect(port._client._data.length).to.equal(116 + 8);
             expect(port._client._data.slice(-8).toString("hex")).to.equal("1103006b00037687");
             expect(port._client._offset).to.equal(0);

--- a/test/ports/rtubufferedport.test.js
+++ b/test/ports/rtubufferedport.test.js
@@ -58,19 +58,19 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -81,13 +81,13 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("83", "hex"));
-                    port._client.receive(new Buffer("04", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("36", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("83", "hex"));
+                    port._client.receive(Buffer.from("04", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("36", "hex"));
                 });
             });
         });
@@ -98,10 +98,10 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("010300000040443A", "hex"));
+                port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
                     for (var i = 0; i < LONG_MSG.length; i += 2) {
-                        port._client.receive(new Buffer(LONG_MSG.slice(i, i + 2), "hex"));
+                        port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "hex"));
                     }
                 });
             });
@@ -113,23 +113,23 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("20", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("ff", "hex")); // illegal char
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("20", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("ff", "hex")); // illegal char
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -140,23 +140,23 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
-                    port._client.receive(new Buffer("20", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("ff", "hex")); // illegal char
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
+                    port._client.receive(Buffer.from("20", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("ff", "hex")); // illegal char
                 });
             });
         });
@@ -167,19 +167,19 @@ describe("Modbus RTU buffered port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -187,7 +187,7 @@ describe("Modbus RTU buffered port", function() {
 
     describe("#write", function() {
         it("should write a valid RTU message to the port", function() {
-            port.write(new Buffer("1103006B00037687", "hex"));
+            port.write(Buffer.from("1103006B00037687", "hex"));
             expect(port._client._data.toString("hex")).to.equal("1103006b00037687");
         });
     });

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -65,10 +65,10 @@ describe("Modbus TCP port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
 
-                if (port._client._data.equals(new Buffer("0001000000061103006B0003", "hex"))) {
-                    port._client.receive(new Buffer("000100000006110366778899", "hex"));
+                if (port._client._data.equals(Buffer.from("0001000000061103006B0003", "hex"))) {
+                    port._client.receive(Buffer.from("000100000006110366778899", "hex"));
                 }
             });
         });
@@ -79,10 +79,10 @@ describe("Modbus TCP port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
 
-                if (port._client._data.equals(new Buffer("0002000000061103006B0003", "hex"))) {
-                    port._client.receive(new Buffer("000200000003118304", "hex"));
+                if (port._client._data.equals(Buffer.from("0002000000061103006B0003", "hex"))) {
+                    port._client.receive(Buffer.from("000200000003118304", "hex"));
                 }
             });
         });
@@ -90,7 +90,7 @@ describe("Modbus TCP port", function() {
 
     describe("#write", function() {
         it("should write a valid TCP message to the port", function() {
-            port.write(new Buffer("1103006B00037687", "hex"));
+            port.write(Buffer.from("1103006B00037687", "hex"));
             expect(port._client._data.toString("hex")).to.equal("0003000000061103006b0003");
         });
     });

--- a/test/ports/tcpportrtubuffered.test.js
+++ b/test/ports/tcpportrtubuffered.test.js
@@ -67,7 +67,7 @@ describe("Modbus TCP RTU buffered port", function() {
                 expect(data.toString("hex")).to.equal("1103667788994fa2");
                 done();
             });
-            send(new Buffer("000100000006110366778899", "hex"));
+            send(Buffer.from("000100000006110366778899", "hex"));
         });
 
         it("should return a valid Modbus TCP RTU message", function(done) {
@@ -75,9 +75,9 @@ describe("Modbus TCP RTU buffered port", function() {
                 expect(data.toString("hex")).to.equal("1103667788994fa2");
                 done();
             });
-            send(new Buffer("0002000000", "hex"));
-            send(new Buffer("0611036677", "hex"));
-            send(new Buffer("8899", "hex"));
+            send(Buffer.from("0002000000", "hex"));
+            send(Buffer.from("0611036677", "hex"));
+            send(Buffer.from("8899", "hex"));
         });
 
         it("should return a valid Modbus TCP exception", function(done) {
@@ -85,7 +85,7 @@ describe("Modbus TCP RTU buffered port", function() {
                 expect(data.toString("hex")).to.equal("1183044136");
                 done();
             });
-            send(new Buffer("000300000003118304", "hex"));
+            send(Buffer.from("000300000003118304", "hex"));
         });
 
         it("Illegal start chars, should synchronize to valid Modbus TCP RTU message", function(done) {
@@ -93,7 +93,7 @@ describe("Modbus TCP RTU buffered port", function() {
                 expect(data.toString("hex")).to.equal("1103667788994fa2");
                 done();
             });
-            send(new Buffer("3456000400000006110366778899", "hex"));
+            send(Buffer.from("3456000400000006110366778899", "hex"));
         });
 
         it("Illegal end chars, should return a valid Modbus TCP RTU message", function(done) {
@@ -101,13 +101,13 @@ describe("Modbus TCP RTU buffered port", function() {
                 expect(data.toString("hex")).to.equal("1103667788994fa2");
                 done();
             });
-            send(new Buffer("0005000000061103667788993456", "hex"));
+            send(Buffer.from("0005000000061103667788993456", "hex"));
         });
     });
 
     describe("#write", function() {
         it("should write a valid TCP RTU message to the port", function() {
-            port.write(new Buffer("0103000500045408", "hex"));
+            port.write(Buffer.from("0103000500045408", "hex"));
             expect(port._client._data.toString("hex")).to.equal("000100000006010300050004");
         });
     });

--- a/test/ports/telnetport.test.js
+++ b/test/ports/telnetport.test.js
@@ -68,19 +68,19 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -91,13 +91,13 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("83", "hex"));
-                    port._client.receive(new Buffer("04", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("36", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("83", "hex"));
+                    port._client.receive(Buffer.from("04", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("36", "hex"));
                 });
             });
         });
@@ -108,10 +108,10 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("010300000040443A", "hex"));
+                port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
                     for (var i = 0; i < LONG_MSG.length; i += 2) {
-                        port._client.receive(new Buffer(LONG_MSG.slice(i, i + 2), "hex"));
+                        port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "hex"));
                     }
                 });
             });
@@ -123,23 +123,23 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("20", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("ff", "hex")); // illegal char
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("20", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("ff", "hex")); // illegal char
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -149,23 +149,23 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
-                    port._client.receive(new Buffer("20", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("54", "hex")); // illegal char
-                    port._client.receive(new Buffer("ff", "hex")); // illegal char
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
+                    port._client.receive(Buffer.from("20", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("54", "hex")); // illegal char
+                    port._client.receive(Buffer.from("ff", "hex")); // illegal char
                 });
             });
         });
@@ -176,19 +176,19 @@ describe("Modbus Telnet port", function() {
                 done();
             });
             port.open(function() {
-                port.write(new Buffer("1103006B00037687", "hex"));
+                port.write(Buffer.from("1103006B00037687", "hex"));
                 setTimeout(function() {
-                    port._client.receive(new Buffer("11", "hex"));
-                    port._client.receive(new Buffer("03", "hex"));
-                    port._client.receive(new Buffer("06", "hex"));
-                    port._client.receive(new Buffer("ae", "hex"));
-                    port._client.receive(new Buffer("41", "hex"));
-                    port._client.receive(new Buffer("56", "hex"));
-                    port._client.receive(new Buffer("52", "hex"));
-                    port._client.receive(new Buffer("43", "hex"));
-                    port._client.receive(new Buffer("40", "hex"));
-                    port._client.receive(new Buffer("49", "hex"));
-                    port._client.receive(new Buffer("ad", "hex"));
+                    port._client.receive(Buffer.from("11", "hex"));
+                    port._client.receive(Buffer.from("03", "hex"));
+                    port._client.receive(Buffer.from("06", "hex"));
+                    port._client.receive(Buffer.from("ae", "hex"));
+                    port._client.receive(Buffer.from("41", "hex"));
+                    port._client.receive(Buffer.from("56", "hex"));
+                    port._client.receive(Buffer.from("52", "hex"));
+                    port._client.receive(Buffer.from("43", "hex"));
+                    port._client.receive(Buffer.from("40", "hex"));
+                    port._client.receive(Buffer.from("49", "hex"));
+                    port._client.receive(Buffer.from("ad", "hex"));
                 });
             });
         });
@@ -196,7 +196,7 @@ describe("Modbus Telnet port", function() {
 
     describe("#write", function() {
         it("should write a valid RTU message to the port", function() {
-            port.write(new Buffer("1103006B00037687", "hex"));
+            port.write(Buffer.from("1103006B00037687", "hex"));
             expect(port._client._data.toString("hex")).to.equal("1103006b00037687");
         });
     });

--- a/test/servers/servertcp.test.js
+++ b/test/servers/servertcp.test.js
@@ -41,7 +41,7 @@ describe("Modbus TCP Server", function() {
         it("should receive a valid Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // FC05 - force single coil, to on 0xff00
-                client.write(new Buffer("00010000000601050005ff00", "hex"));
+                client.write(Buffer.from("00010000000601050005ff00", "hex"));
             });
 
             client.once("data", function(data) {
@@ -58,7 +58,7 @@ describe("Modbus TCP Server", function() {
         it("should receive a valid unhandled function Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // FC07 - unhandled function
-                client.write(new Buffer("000100000006010700000000", "hex"));
+                client.write(Buffer.from("000100000006010700000000", "hex"));
             });
 
             client.once("data", function(data) {
@@ -71,7 +71,7 @@ describe("Modbus TCP Server", function() {
         it("should receive a valid slave failure Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // FC03 to error triggering address
-                client.write(new Buffer("0001000000060103003E0001", "hex"));
+                client.write(Buffer.from("0001000000060103003E0001", "hex"));
             });
 
             client.once("data", function(data) {

--- a/test/servers/servertcpCallback.test.js
+++ b/test/servers/servertcpCallback.test.js
@@ -47,7 +47,7 @@ describe("Modbus TCP Server Callback", function() {
         it("should receive a valid Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 // FC05 - force single coil, to on 0xff00
-                client.write(new Buffer("00010000000601050005ff00", "hex"));
+                client.write(Buffer.from("00010000000601050005ff00", "hex"));
             });
 
             client.once("data", function(data) {
@@ -64,7 +64,7 @@ describe("Modbus TCP Server Callback", function() {
         it("should receive a valid Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 // FC07 - unhandled function
-                client.write(new Buffer("000100000006010700000000", "hex"));
+                client.write(Buffer.from("000100000006010700000000", "hex"));
             });
 
             client.once("data", function(data) {
@@ -77,7 +77,7 @@ describe("Modbus TCP Server Callback", function() {
         it("should receive a valid slave failure Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // FC03 to error triggering address
-                client.write(new Buffer("0001000000060103003E0001", "hex"));
+                client.write(Buffer.from("0001000000060103003E0001", "hex"));
             });
 
             client.once("data", function(data) {

--- a/test/servers/servertcpPromise.test.js
+++ b/test/servers/servertcpPromise.test.js
@@ -58,7 +58,7 @@ describe("Modbus TCP Server Promise", function() {
         it("should receive a valid Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 // FC05 - force single coil, to on 0xff00
-                client.write(new Buffer("00010000000601050005ff00", "hex"));
+                client.write(Buffer.from("00010000000601050005ff00", "hex"));
             });
 
             client.once("data", function(data) {
@@ -75,7 +75,7 @@ describe("Modbus TCP Server Promise", function() {
         it("should receive a valid Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 // FC07 - unhandled function
-                client.write(new Buffer("000100000006010700000000", "hex"));
+                client.write(Buffer.from("000100000006010700000000", "hex"));
             });
 
             client.once("data", function(data) {
@@ -88,7 +88,7 @@ describe("Modbus TCP Server Promise", function() {
         it("should receive a valid slave failure Modbus TCP message", function(done) {
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // FC03 to error triggering address
-                client.write(new Buffer("0001000000060103003E0001", "hex"));
+                client.write(Buffer.from("0001000000060103003E0001", "hex"));
             });
 
             client.once("data", function(data) {

--- a/test/utils/crc16.test.js
+++ b/test/utils/crc16.test.js
@@ -9,14 +9,14 @@ describe("Modbus CRC16", function() {
 
     describe("crc16() - calculate checksum", function() {
         it("should calculate a valid checksum", function(done) {
-            var buffer = new Buffer([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+            var buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
             var crc = crc16(buffer);
             expect(crc).to.equal(50227);
             done();
         });
 
         it("should calculate a valid checksum", function(done) {
-            var buffer = new Buffer("110100130025", "hex");
+            var buffer = Buffer.from("110100130025", "hex");
             var crc = crc16(buffer);
             expect(crc).to.equal(33806);
             done();

--- a/test/utils/lrc.test.js
+++ b/test/utils/lrc.test.js
@@ -9,7 +9,7 @@ describe("Modbus LRC", function() {
 
     describe("lrc() - calculate checksum", function() {
         it("should calculate a valid checksum", function(done) {
-            var buffer = new Buffer("1103006B0003", "hex");
+            var buffer = Buffer.from("1103006B0003", "hex");
             var lrc = calculateLrc(buffer);
             expect(lrc).to.equal(126);
             done();


### PR DESCRIPTION
`new Buffer()` is deprecated [1] in new versions of nodejs. this PR replace it with `Buffer.alloc` and `Buffer.from`


[1] https://nodejs.org/docs/latest-v10.x/api/buffer.html