### PR TITLE
Timeout on transactions

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -106,6 +106,8 @@ var addConnctionAPI = function(Modbus) {
         var TcpPort = require("../ports/tcpport");
         if (this._timeout) {
             options.timeout = this._timeout;
+        } else if (options.timeout) {
+            this._timeout = options.timeout;
         }
         this._port = new TcpPort(ip, options);
 
@@ -135,6 +137,8 @@ var addConnctionAPI = function(Modbus) {
         var TcpRTUBufferedPort = require("../ports/tcprtubufferedport");
         if (this._timeout) {
             options.timeout = this._timeout;
+        } else if (options.timeout) {
+            this._timeout = options.timeout;
         }
         this._port = new TcpRTUBufferedPort(ip, options);
 
@@ -165,6 +169,8 @@ var addConnctionAPI = function(Modbus) {
         var TelnetPort = require("../ports/telnetport");
         if (this._timeout) {
             options.timeout = this._timeout;
+        } else if (options.timeout) {
+            this._timeout = options.timeout;
         }
         this._port = new TelnetPort(ip, options);
 


### PR DESCRIPTION
Hi,

we're using the library to connect to a [Moxa NPort 5130](https://www.moxa.com/product/nport_5130.htm).
During a maintenance by pure chance we disconnect the serial port and the software did not reply with any kind of error or notification on the next reading round (we read on a given interval the values inside some registers).

I introduced the timeout also on transactions using the same value passed on the connect. In this way our software get notified by the timeout error and the reading round is ignored.

We consider this valuable to be in the library. I honestly did not understand if there were any other ways to achieve it.

Thanks for the commitment on the library. 
Hope to brought value,

have a great day,
Dario