### PR TITLE
Fixes #130

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -6,17 +6,17 @@ var ModbusRTU = require("../index");
 var vector = {
     getInputRegister: function(addr) { return addr; },
     getHoldingRegister: function(addr) { return addr + 8000; },
-    getMultipleInputRegisters: function (startAddr, length){
-        var values=[];
-        for(var i=0;i<length;i++){
-            values[i]=startAddr+i;
+    getMultipleInputRegisters: function (startAddr, length) {
+        var values = [];
+        for (var i = 0; i < length; i++) {
+            values[i] = startAddr + i;
         }
         return values;
     },
-    getMultipleHoldingRegisters: function (startAddr, length){
-        var values=[];
-        for(var i=0;i<length;i++){
-            values[i]=startAddr+i+8000;
+    getMultipleHoldingRegisters: function (startAddr, length) {
+        var values = [];
+        for (var i = 0; i < length; i++) {
+            values[i] = startAddr + i + 8000;
         }
         return values;
     },

--- a/examples/server.js
+++ b/examples/server.js
@@ -6,14 +6,14 @@ var ModbusRTU = require("../index");
 var vector = {
     getInputRegister: function(addr) { return addr; },
     getHoldingRegister: function(addr) { return addr + 8000; },
-    getMultipleInputRegisters: function (startAddr, length) {
+    getMultipleInputRegisters: function(startAddr, length) {
         var values = [];
         for (var i = 0; i < length; i++) {
             values[i] = startAddr + i;
         }
         return values;
     },
-    getMultipleHoldingRegisters: function (startAddr, length) {
+    getMultipleHoldingRegisters: function(startAddr, length) {
         var values = [];
         for (var i = 0; i < length; i++) {
             values[i] = startAddr + i + 8000;

--- a/examples/server.js
+++ b/examples/server.js
@@ -6,6 +6,20 @@ var ModbusRTU = require("../index");
 var vector = {
     getInputRegister: function(addr) { return addr; },
     getHoldingRegister: function(addr) { return addr + 8000; },
+    getMultipleInputRegisters: function (startAddr, length){
+        var values=[];
+        for(var i=0;i<length;i++){
+            values[i]=startAddr+i;
+        }
+        return values;
+    },
+    getMultipleHoldingRegisters: function (startAddr, length){
+        var values=[];
+        for(var i=0;i<length;i++){
+            values[i]=startAddr+i+8000;
+        }
+        return values;
+    },
     getCoil: function(addr) { return (addr % 2) === 0; },
     setRegister: function(addr, value) { console.log("set register", addr, value); return; },
     setCoil: function(addr, value) { console.log("set coil", addr, value); return; }

--- a/servers/servertcp.js
+++ b/servers/servertcp.js
@@ -322,7 +322,7 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
 
         if(vector.getMultipleHoldingRegisters.length===4){
             vector.getMultipleHoldingRegisters(address,length,unitID,function(err,values){
-                if(values.length!=length){
+                if(!err && values.length!=length){
                     var error=new Error("Requested address length and response length do not match");
                     callback(error);
                     throw error;
@@ -436,7 +436,7 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
 
         if(vector.getMultipleInputRegisters.length===4){
             vector.getMultipleInputRegisters(address,length,unitID,function(err,values){
-                if(values.length!=length){
+                if(!err && values.length!=length){
                     var error=new Error("Requested address length and response length do not match");
                     callback(error);
                     throw error;

--- a/servers/servertcp.js
+++ b/servers/servertcp.js
@@ -285,39 +285,81 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
     var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
     responseBuffer.writeUInt8(length * 2, 2);
 
-    // read registers
-    if (vector.getHoldingRegister) {
-        var callbackInvoked = false;
-        var cbCount = 0;
-        var buildCb = function(i) {
-            return function(err, value) {
-                if (err) {
-                    if (!callbackInvoked) {
-                        callbackInvoked = true;
-                        callback(err);
-                    }
-
-                    return;
-                }
-
-                cbCount = cbCount + 1;
-
-                responseBuffer.writeUInt16BE(value, 3 + i * 2);
-
-                if (cbCount === length && !callbackInvoked) {
-                    modbusSerialDebug({ action: "FC3 response", responseBuffer: responseBuffer });
-
+    var callbackInvoked = false;
+    var cbCount = 0;
+    var buildCb = function(i) {
+        return function(err, value) {
+            if (err) {
+                if (!callbackInvoked) {
                     callbackInvoked = true;
-                    callback(null, responseBuffer);
+                    callback(err);
                 }
-            };
-        };
 
-        if (length === 0)
-            callback({
-                modbusErrorCode: 0x02, // Illegal address
-                msg: "Invalid length"
-            });
+                return;
+            }
+
+            cbCount = cbCount + 1;
+
+            responseBuffer.writeUInt16BE(value, 3 + i * 2);
+
+            if (cbCount === length && !callbackInvoked) {
+                modbusSerialDebug({ action: "FC3 response", responseBuffer: responseBuffer });
+
+                callbackInvoked = true;
+                callback(null, responseBuffer);
+            }
+        };
+    };
+
+    if (length === 0)
+        callback({
+            modbusErrorCode: 0x02, // Illegal address
+            msg: "Invalid length"
+        });
+
+    // read registers
+    if (vector.getMultipleHoldingRegisters && length > 1) {
+
+        if(vector.getMultipleHoldingRegisters.length===4){
+            vector.getMultipleHoldingRegisters(address,length,unitID,function(err,values){
+                if(values.length!=length){
+                    var error=new Error("Requested address length and response length do not match");
+                    callback(error);
+                    throw error;
+                }else{
+                    for (var i = 0; i < length; i++) {
+                        var cb = buildCb(i);
+                        try {
+                            cb(err, values[i]);
+                        }
+                        catch(err) {
+                            cb(err);
+                        }
+                    }
+                }
+            })
+        }else{
+            var values=vector.getMultipleHoldingRegisters(address,length,unitID);
+            if(values.length!=length){
+                var error=new Error("Requested address length and response length do not match");
+                callback(error);
+                throw error;
+            }else{
+                for (var i = 0; i < length; i++) {
+                    var cb = buildCb(i);
+                    try {
+                        var promiseOrValue = values[i];
+                        _handlePromiseOrValue(promiseOrValue, cb);
+                    }
+                    catch(err) {
+                        cb(err);
+                    }
+                }
+            }
+        }
+
+    }
+    else if (vector.getHoldingRegister) {
 
         for (var i = 0; i < length; i++) {
             var cb = buildCb(i);
@@ -359,38 +401,79 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
     var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
     responseBuffer.writeUInt8(length * 2, 2);
 
-    if (vector.getInputRegister) {
-        var callbackInvoked = false;
-        var cbCount = 0;
-        var buildCb = function(i) {
-            return function(err, value) {
-                if (err) {
-                    if (!callbackInvoked) {
-                        callbackInvoked = true;
-                        callback(err);
-                    }
-
-                    return;
-                }
-
-                cbCount = cbCount + 1;
-
-                responseBuffer.writeUInt16BE(value, 3 + i * 2);
-
-                if (cbCount === length && !callbackInvoked) {
-                    modbusSerialDebug({ action: "FC4 response", responseBuffer: responseBuffer });
-
+    var callbackInvoked = false;
+    var cbCount = 0;
+    var buildCb = function(i) {
+        return function(err, value) {
+            if (err) {
+                if (!callbackInvoked) {
                     callbackInvoked = true;
-                    callback(null, responseBuffer);
+                    callback(err);
                 }
-            };
-        };
 
-        if (length === 0)
-            callback({
-                modbusErrorCode: 0x02, // Illegal address
-                msg: "Invalid length"
-            });
+                return;
+            }
+
+            cbCount = cbCount + 1;
+
+            responseBuffer.writeUInt16BE(value, 3 + i * 2);
+
+            if (cbCount === length && !callbackInvoked) {
+                modbusSerialDebug({ action: "FC4 response", responseBuffer: responseBuffer });
+
+                callbackInvoked = true;
+                callback(null, responseBuffer);
+            }
+        };
+    };
+
+    if (length === 0)
+        callback({
+            modbusErrorCode: 0x02, // Illegal address
+            msg: "Invalid length"
+        });
+    if (vector.getMultipleInputRegisters && length > 1) {
+
+        if(vector.getMultipleInputRegisters.length===4){
+            vector.getMultipleInputRegisters(address,length,unitID,function(err,values){
+                if(values.length!=length){
+                    var error=new Error("Requested address length and response length do not match");
+                    callback(error);
+                    throw error;
+                }else{
+                    for (var i = 0; i < length; i++) {
+                        var cb = buildCb(i);
+                        try {
+                            cb(err, values[i]);
+                        }
+                        catch(err) {
+                            cb(err);
+                        }
+                    }
+                }
+            })
+        }else{
+            var values=vector.getMultipleInputRegisters(address,length,unitID);
+            if(values.length!=length){
+                var error=new Error("Requested address length and response length do not match");
+                callback(error);
+                throw error;
+            }else{
+                for (var i = 0; i < length; i++) {
+                    var cb = buildCb(i);
+                    try {
+                        var promiseOrValue = values[i];
+                        _handlePromiseOrValue(promiseOrValue, cb);
+                    }
+                    catch(err) {
+                        cb(err);
+                    }
+                }
+            }
+        }
+
+    }
+    else if (vector.getInputRegister) {
 
         for (var i = 0; i < length; i++) {
             var cb = buildCb(i);

--- a/servers/servertcp.js
+++ b/servers/servertcp.js
@@ -287,8 +287,8 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
 
     var callbackInvoked = false;
     var cbCount = 0;
-    var buildCb = function(i) {
-        return function(err, value) {
+    var buildCb = function (i) {
+        return function (err, value) {
             if (err) {
                 if (!callbackInvoked) {
                     callbackInvoked = true;
@@ -303,7 +303,7 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
             responseBuffer.writeUInt16BE(value, 3 + i * 2);
 
             if (cbCount === length && !callbackInvoked) {
-                modbusSerialDebug({ action: "FC3 response", responseBuffer: responseBuffer });
+                modbusSerialDebug({action: "FC3 response", responseBuffer: responseBuffer});
 
                 callbackInvoked = true;
                 callback(null, responseBuffer);
@@ -320,38 +320,38 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
     // read registers
     if (vector.getMultipleHoldingRegisters && length > 1) {
 
-        if(vector.getMultipleHoldingRegisters.length===4){
-            vector.getMultipleHoldingRegisters(address,length,unitID,function(err,values){
-                if(!err && values.length!=length){
-                    var error=new Error("Requested address length and response length do not match");
+        if (vector.getMultipleHoldingRegisters.length === 4) {
+            vector.getMultipleHoldingRegisters(address, length, unitID, function (err, values) {
+                if (!err && values.length != length) {
+                    var error = new Error("Requested address length and response length do not match");
                     callback(error);
                     throw error;
-                }else{
+                } else {
                     for (var i = 0; i < length; i++) {
                         var cb = buildCb(i);
                         try {
                             cb(err, values[i]);
                         }
-                        catch(err) {
+                        catch (err) {
                             cb(err);
                         }
                     }
                 }
             })
-        }else{
-            var values=vector.getMultipleHoldingRegisters(address,length,unitID);
-            if(values.length!=length){
-                var error=new Error("Requested address length and response length do not match");
+        } else {
+            var values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            if (values.length != length) {
+                var error = new Error("Requested address length and response length do not match");
                 callback(error);
                 throw error;
-            }else{
+            } else {
                 for (var i = 0; i < length; i++) {
                     var cb = buildCb(i);
                     try {
                         var promiseOrValue = values[i];
                         _handlePromiseOrValue(promiseOrValue, cb);
                     }
-                    catch(err) {
+                    catch (err) {
                         cb(err);
                     }
                 }
@@ -372,7 +372,7 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
                     _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
-            catch(err) {
+            catch (err) {
                 cb(err);
             }
         }
@@ -403,8 +403,8 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
 
     var callbackInvoked = false;
     var cbCount = 0;
-    var buildCb = function(i) {
-        return function(err, value) {
+    var buildCb = function (i) {
+        return function (err, value) {
             if (err) {
                 if (!callbackInvoked) {
                     callbackInvoked = true;
@@ -419,7 +419,7 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
             responseBuffer.writeUInt16BE(value, 3 + i * 2);
 
             if (cbCount === length && !callbackInvoked) {
-                modbusSerialDebug({ action: "FC4 response", responseBuffer: responseBuffer });
+                modbusSerialDebug({action: "FC4 response", responseBuffer: responseBuffer});
 
                 callbackInvoked = true;
                 callback(null, responseBuffer);
@@ -434,38 +434,38 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
         });
     if (vector.getMultipleInputRegisters && length > 1) {
 
-        if(vector.getMultipleInputRegisters.length===4){
-            vector.getMultipleInputRegisters(address,length,unitID,function(err,values){
-                if(!err && values.length!=length){
-                    var error=new Error("Requested address length and response length do not match");
+        if (vector.getMultipleInputRegisters.length === 4) {
+            vector.getMultipleInputRegisters(address, length, unitID, function (err, values) {
+                if (!err && values.length != length) {
+                    var error = new Error("Requested address length and response length do not match");
                     callback(error);
                     throw error;
-                }else{
+                } else {
                     for (var i = 0; i < length; i++) {
                         var cb = buildCb(i);
                         try {
                             cb(err, values[i]);
                         }
-                        catch(err) {
+                        catch (err) {
                             cb(err);
                         }
                     }
                 }
             })
-        }else{
-            var values=vector.getMultipleInputRegisters(address,length,unitID);
-            if(values.length!=length){
-                var error=new Error("Requested address length and response length do not match");
+        } else {
+            var values = vector.getMultipleInputRegisters(address, length, unitID);
+            if (values.length != length) {
+                var error = new Error("Requested address length and response length do not match");
                 callback(error);
                 throw error;
-            }else{
+            } else {
                 for (var i = 0; i < length; i++) {
                     var cb = buildCb(i);
                     try {
                         var promiseOrValue = values[i];
                         _handlePromiseOrValue(promiseOrValue, cb);
                     }
-                    catch(err) {
+                    catch (err) {
                         cb(err);
                     }
                 }
@@ -486,7 +486,7 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
                     _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
-            catch(err) {
+            catch (err) {
                 cb(err);
             }
         }


### PR DESCRIPTION
Added two new functions to vector:
1. `getMultipleInputRegisters`
2. `getMultipleHoldingRegisters`

If defined, these functions will be called once for each request. These functions should return an array of values. If the length of the returned array does not match the length of the requested number of register values, and Error is thrown and Exception 4 is sent.

If not defined, the old technique of calling `getInputRegister` and `getHoldingRegister` multiple times is used. This has been done in case someone still wants to use the old technique or has the old code but has updated package.