### PR TITLE
typescript import fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -734,6 +734,7 @@ require("./apis/promise")(ModbusRTU);
 
 // exports
 module.exports = ModbusRTU;
+module.exports.default = ModbusRTU;
 module.exports.TestPort = require("./ports/testport");
 try {
     module.exports.RTUBufferedPort = require("./ports/rtubufferedport");


### PR DESCRIPTION
Now 
`import ModbusRTU from 'modbus-serial';`
raise error
TypeError: modbus_serial_1.default is not a constructor

This small fix add default to exports.