### PR TITLE
fixes issue #241

### DIFF
--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -80,7 +80,13 @@ function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callbac
     // build answer
     var dataBytes = parseInt((length - 1) / 8 + 1);
     var responseBuffer = Buffer.alloc(3 + dataBytes + 2);
-    responseBuffer.writeUInt8(dataBytes, 2);
+    try {
+        responseBuffer.writeUInt8(dataBytes, 2);
+    }
+    catch (err) {
+        callback(err);
+        return;
+    }
 
     var vectorCB;
     if(fc === 1)
@@ -160,7 +166,13 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
 
     // build answer
     var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
-    responseBuffer.writeUInt8(length * 2, 2);
+    try {
+        responseBuffer.writeUInt8(length * 2, 2);
+    }
+    catch (err) {
+        callback(err);
+        return;
+    }
 
     var callbackInvoked = false;
     var cbCount = 0;
@@ -280,7 +292,13 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
 
     // build answer
     var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
-    responseBuffer.writeUInt8(length * 2, 2);
+    try {
+        responseBuffer.writeUInt8(length * 2, 2);
+    }
+    catch (err) {
+        callback(err);
+        return;
+    }
 
     var callbackInvoked = false;
     var cbCount = 0;

--- a/test/servers/servertcp.test.js
+++ b/test/servers/servertcp.test.js
@@ -104,6 +104,49 @@ describe("Modbus TCP Server (no serverID)", function() {
 
         // TODO: exceptions
     });
+
+    describe("large client request", function() {
+        it("should handle a large request without crash successfully (FC1)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018104");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC3)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018304");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC4)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018404");
+                done();
+            });
+        });
+
+        // TODO: exceptions
+    });
 });
 
 describe("Modbus TCP Server (serverID = requestID)", function() {

--- a/test/servers/servertcpCallback.test.js
+++ b/test/servers/servertcpCallback.test.js
@@ -112,4 +112,45 @@ describe("Modbus TCP Server Callback", function() {
 
         // TODO: exceptions
     });
+
+    describe("large client request", function() {
+        it("should handle a large request without crash successfully (FC1)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018104");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC3)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018304");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC4)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018404");
+                done();
+            });
+        });
+    });
 });

--- a/test/servers/servertcpPromise.test.js
+++ b/test/servers/servertcpPromise.test.js
@@ -121,4 +121,45 @@ describe("Modbus TCP Server Promise", function() {
 
         // TODO: exceptions
     });
+
+    describe("large client request", function() {
+        it("should handle a large request without crash successfully (FC1)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018104");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC3)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018304");
+                done();
+            });
+        });
+
+        it("should handle a large request without crash successfully (FC4)", function(done) {
+            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+                // request 65535 registers at once
+                client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
+            });
+
+            client.once("data", function(data) {
+                // A valid error message, code 0x04 - Slave failure
+                expect(data.toString("hex")).to.equal("000100000003018404");
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR fixes an issue where the modbus-serial library would throw a unhandled exception if a client makes a request for a large amount of registers at once. The basic idea is, that this exceeds the write calls to the UInt8 buffers. To tackle this, these calls are encapsulated in try/catch blocks and a slave error of 0x04 is returned to the client.

I decided to not throw this further to the `ServerTCP._parseModbusBuffer()` function for output through the debug function, since these errors may be best handled directly in the handler functions. It may be desired to do this in the future though.

Tests included.