### PR TITLE
Use proper ES6 import syntax for TypeScript types

### DIFF
--- a/ServerTCP.d.ts
+++ b/ServerTCP.d.ts
@@ -1,4 +1,4 @@
-import events from 'events'
+import * as events from 'events';
 
 export class ServerTCP extends events.EventEmitter {
     constructor(vector: IServiceVector, options: IServerOptions);


### PR DESCRIPTION
The built-in events NodeJS module does not have a default export. This prevents modbus-serial from compiling (as of release 7.4.1).

By using the proper ES6 import syntax, the module is imported without error.