### PR TITLE
Add framework examples #240

### DIFF
--- a/examples/polling_RTU.js
+++ b/examples/polling_RTU.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console, spaced-comment */
 
 //==============================================================
-// This is an example of polling (reading) Holding Registers
+// This is example of polling (reading) Holding Registers
 // on a regular scan interval with timeouts enabled.
 // For robust behaviour, the next action is not activated
 // until the previous action is completed (callback served).

--- a/examples/polling_RTU.js
+++ b/examples/polling_RTU.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console, spaced-comment */
 
 //==============================================================
-// This is example of polling (reading) Holding Registers
+// This is an example of polling (reading) Holding Registers
 // on a regular scan interval with timeouts enabled.
 // For robust behaviour, the next action is not activated
 // until the previous action is completed (callback served).

--- a/examples/polling_RTU.js
+++ b/examples/polling_RTU.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, spaced-comment */
+/* eslint-disable no-console, spaced-comment, func-call-spacing, no-spaced-func */
 
 //==============================================================
 // This is an example of polling (reading) Holding Registers
@@ -7,30 +7,29 @@
 // until the previous action is completed (callback served).
 //==============================================================
 
-"use strict"
+"use strict";
 
 //==============================================================
 // create an empty modbus client
-var ModbusRTU   = require ('modbus-serial');
+var ModbusRTU   = require ("modbus-serial");
 var client      = new ModbusRTU();
 
-var mbsStatus   = 'Initializing...';    // holds a status of Modbus
+var mbsStatus   = "Initializing...";    // holds a status of Modbus
 
 // Modbus 'state' constants
-var MBS_STATE_INIT          = 'State init';
-var MBS_STATE_IDLE          = 'State idle';
-var MBS_STATE_NEXT          = 'State next';
-var MBS_STATE_GOOD_READ     = 'State good (read)';
-var MBS_STATE_FAIL_READ     = 'State fail (read)';
-var MBS_STATE_GOOD_CONNECT  = 'State good (port)';
-var MBS_STATE_FAIL_CONNECT  = 'State fail (port)';
+var MBS_STATE_INIT          = "State init";
+var MBS_STATE_IDLE          = "State idle";
+var MBS_STATE_NEXT          = "State next";
+var MBS_STATE_GOOD_READ     = "State good (read)";
+var MBS_STATE_FAIL_READ     = "State fail (read)";
+var MBS_STATE_GOOD_CONNECT  = "State good (port)";
+var MBS_STATE_FAIL_CONNECT  = "State fail (port)";
 
 // Modbus configuration values
 var mbsId       = 1;
 var mbsScan     = 1000;
 var mbsTimeout  = 5000;
 var mbsState    = MBS_STATE_INIT;
-var mbsBufData;
 
 
 //==============================================================
@@ -41,11 +40,11 @@ var connectClient = function()
     client.setTimeout (mbsTimeout);
 
     // try to connect
-    client.connectRTUBuffered ("COM9", { baudRate: 9600, parity: 'even', dataBits:8, stopBits:1 })
+    client.connectRTUBuffered ("COM9", { baudRate: 9600, parity: "even", dataBits: 8, stopBits: 1 })
         .then(function()
         {
             mbsState  = MBS_STATE_GOOD_CONNECT;
-            mbsStatus = 'Connected, wait for reading...';
+            mbsStatus = "Connected, wait for reading...";
             console.log(mbsStatus);
         })
         .catch(function(e)
@@ -54,7 +53,7 @@ var connectClient = function()
             mbsStatus = e.message;
             console.log(e);
         });
-}
+};
 
 
 //==============================================================
@@ -65,8 +64,7 @@ var readModbusData = function()
         .then(function(data)
         {
             mbsState   = MBS_STATE_GOOD_READ;
-            mbsStatus  = 'success';
-            mbsBufData = data.buffer.swap16();
+            mbsStatus  = "success";
             console.log(data.buffer);
         })
         .catch(function(e)
@@ -75,7 +73,7 @@ var readModbusData = function()
             mbsStatus = e.message;
             console.log(e);
         });
-}
+};
 
 
 //==============================================================
@@ -118,7 +116,7 @@ var runModbus = function()
     console.log(nextAction);
 
     // execute "next action" function if defined
-    if (nextAction != undefined)
+    if (nextAction !== undefined)
     {
         nextAction();
         mbsState = MBS_STATE_IDLE;
@@ -126,7 +124,7 @@ var runModbus = function()
 
     // set for next run
     setTimeout (runModbus, mbsScan);
-}
+};
 
 //==============================================================
 runModbus();

--- a/examples/polling_RTU.js
+++ b/examples/polling_RTU.js
@@ -1,0 +1,132 @@
+/* eslint-disable no-console, spaced-comment */
+
+//==============================================================
+// This is an example of polling (reading) Holding Registers
+// on a regular scan interval with timeouts enabled.
+// For robust behaviour, the next action is not activated
+// until the previous action is completed (callback served).
+//==============================================================
+
+"use strict"
+
+//==============================================================
+// create an empty modbus client
+var ModbusRTU   = require ('modbus-serial');
+var client      = new ModbusRTU();
+
+var mbsStatus   = 'Initializing...';    // holds a status of Modbus
+
+// Modbus 'state' constants
+var MBS_STATE_INIT          = 'State init';
+var MBS_STATE_IDLE          = 'State idle';
+var MBS_STATE_NEXT          = 'State next';
+var MBS_STATE_GOOD_READ     = 'State good (read)';
+var MBS_STATE_FAIL_READ     = 'State fail (read)';
+var MBS_STATE_GOOD_CONNECT  = 'State good (port)';
+var MBS_STATE_FAIL_CONNECT  = 'State fail (port)';
+
+// Modbus configuration values
+var mbsId       = 1;
+var mbsScan     = 1000;
+var mbsTimeout  = 5000;
+var mbsState    = MBS_STATE_INIT;
+var mbsBufData;
+
+
+//==============================================================
+var connectClient = function()
+{
+    // set requests parameters
+    client.setID      (mbsId);
+    client.setTimeout (mbsTimeout);
+
+    // try to connect
+    client.connectRTUBuffered ("COM9", { baudRate: 9600, parity: 'even', dataBits:8, stopBits:1 })
+        .then(function()
+        {
+            mbsState  = MBS_STATE_GOOD_CONNECT;
+            mbsStatus = 'Connected, wait for reading...';
+            console.log(mbsStatus);
+        })
+        .catch(function(e)
+        {
+            mbsState  = MBS_STATE_FAIL_CONNECT;
+            mbsStatus = e.message;
+            console.log(e);
+        });
+}
+
+
+//==============================================================
+var readModbusData = function()
+{
+    // try to read data
+    client.readHoldingRegisters (5, 1)
+        .then(function(data)
+        {
+            mbsState   = MBS_STATE_GOOD_READ;
+            mbsStatus  = 'success';
+            mbsBufData = data.buffer.swap16();
+            console.log(data.buffer);
+        })
+        .catch(function(e)
+        {
+            mbsState  = MBS_STATE_FAIL_READ;
+            mbsStatus = e.message;
+            console.log(e);
+        });
+}
+
+
+//==============================================================
+var runModbus = function()
+{
+    var nextAction;
+
+    switch (mbsState)
+    {
+        case MBS_STATE_INIT:
+            nextAction = connectClient;
+            break;
+
+        case MBS_STATE_NEXT:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_GOOD_CONNECT:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_FAIL_CONNECT:
+            nextAction = connectClient;
+            break;
+
+        case MBS_STATE_GOOD_READ:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_FAIL_READ:
+            if (client.isOpen)  { mbsState = MBS_STATE_NEXT;  }
+            else                { nextAction = connectClient; }
+            break;
+
+        default:
+            // nothing to do, keep scanning until actionable case
+    }
+
+    console.log();
+    console.log(nextAction);
+
+    // execute "next action" function if defined
+    if (nextAction != undefined)
+    {
+        nextAction();
+        mbsState = MBS_STATE_IDLE;
+    }
+
+    // set for next run
+    setTimeout (runModbus, mbsScan);
+}
+
+//==============================================================
+runModbus();

--- a/examples/polling_TCP.js
+++ b/examples/polling_TCP.js
@@ -23,7 +23,7 @@ var MBS_STATE_NEXT          = "State next";
 var MBS_STATE_GOOD_READ     = "State good (read)";
 var MBS_STATE_FAIL_READ     = "State fail (read)";
 var MBS_STATE_GOOD_CONNECT  = "State good (port)";
-var MBS_STATE_FAIL_CONNECT  = 'State fail (port)";
+var MBS_STATE_FAIL_CONNECT  = "State fail (port)";
 
 // Modbus TCP configuration values
 var mbsId       = 1;

--- a/examples/polling_TCP.js
+++ b/examples/polling_TCP.js
@@ -1,0 +1,139 @@
+/* eslint-disable no-console, spaced-comment */
+
+//==============================================================
+// This is an example of polling (reading) Holding Registers
+// on a regular scan interval with timeouts enabled.
+// For robust behaviour, the next action is not activated
+// until the previous action is completed (callback served).
+//==============================================================
+
+"use strict"
+
+//==============================================================
+// create an empty modbus client
+var ModbusRTU   = require ('modbus-serial');
+var client      = new ModbusRTU();
+
+var mbsStatus   = 'Initializing...';    // holds a status of Modbus
+
+// Modbus 'state' constants
+var MBS_STATE_INIT          = 'State init';
+var MBS_STATE_IDLE          = 'State idle';
+var MBS_STATE_NEXT          = 'State next';
+var MBS_STATE_GOOD_READ     = 'State good (read)';
+var MBS_STATE_FAIL_READ     = 'State fail (read)';
+var MBS_STATE_GOOD_CONNECT  = 'State good (port)';
+var MBS_STATE_FAIL_CONNECT  = 'State fail (port)';
+
+// Modbus TCP configuration values
+var mbsId       = 1;
+var mbsPort     = 502;
+//var mbsHost     = '10.8.0.4';
+var mbsHost     = '192.168.20.2';
+var mbsScan     = 1000;
+var mbsTimeout  = 5000;
+var mbsState    = MBS_STATE_INIT;
+var mbsBufData;
+
+
+//==============================================================
+var connectClient = function()
+{
+    // close port (NOTE: important in order not to create multiple connections)
+    client.close();
+
+    // set requests parameters
+    client.setID      (mbsId);
+    client.setTimeout (mbsTimeout);
+
+    // try to connect
+    client.connectTCP (mbsHost, { port: mbsPort })
+        .then(function()
+        {
+            mbsState  = MBS_STATE_GOOD_CONNECT;
+            mbsStatus = 'Connected, wait for reading...';
+            console.log(mbsStatus);
+        })
+        .catch(function(e)
+        {
+            mbsState  = MBS_STATE_FAIL_CONNECT;
+            mbsStatus = e.message;
+            console.log(e);
+        });
+        
+}
+
+
+//==============================================================
+var readModbusData = function()
+{
+    // try to read data
+    client.readHoldingRegisters (0, 18)
+        .then(function(data)
+        {
+            mbsState   = MBS_STATE_GOOD_READ;
+            mbsStatus  = 'success';
+            mbsBufData = data.buffer.swap16();
+            console.log(data.buffer);
+        })
+        .catch(function(e)
+        {
+            mbsState  = MBS_STATE_FAIL_READ;
+            mbsStatus = e.message;
+            console.log(e);
+        });
+}
+
+
+//==============================================================
+var runModbus = function()
+{
+    var nextAction;
+    
+    switch (mbsState)
+    {
+        case MBS_STATE_INIT:
+            nextAction = connectClient;
+            break;
+
+        case MBS_STATE_NEXT:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_GOOD_CONNECT:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_FAIL_CONNECT:
+            nextAction = connectClient;
+            break;
+
+        case MBS_STATE_GOOD_READ:
+            nextAction = readModbusData;
+            break;
+
+        case MBS_STATE_FAIL_READ:
+            if (client.isOpen)  { mbsState = MBS_STATE_NEXT;  }
+            else                { nextAction = connectClient; }
+            break;
+
+        default:
+            // nothing to do, keep scanning until actionable case
+    }
+
+    console.log();
+    console.log(nextAction);
+
+    // execute "next action" function if defined
+    if (nextAction != undefined) 
+    { 
+        nextAction();
+        mbsState = MBS_STATE_IDLE; 
+    }
+    
+    // set for next run
+    setTimeout (runModbus, mbsScan);
+}
+
+//==============================================================
+runModbus();

--- a/examples/polling_TCP.js
+++ b/examples/polling_TCP.js
@@ -60,7 +60,7 @@ var connectClient = function()
             mbsStatus = e.message;
             console.log(e);
         });
-        
+
 }
 
 
@@ -89,7 +89,7 @@ var readModbusData = function()
 var runModbus = function()
 {
     var nextAction;
-    
+
     switch (mbsState)
     {
         case MBS_STATE_INIT:
@@ -125,12 +125,12 @@ var runModbus = function()
     console.log(nextAction);
 
     // execute "next action" function if defined
-    if (nextAction != undefined) 
-    { 
+    if (nextAction != undefined)
+    {
         nextAction();
-        mbsState = MBS_STATE_IDLE; 
+        mbsState = MBS_STATE_IDLE;
     }
-    
+
     // set for next run
     setTimeout (runModbus, mbsScan);
 }

--- a/examples/polling_TCP.js
+++ b/examples/polling_TCP.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, spaced-comment */
+/* eslint-disable no-console, spaced-comment, func-call-spacing, no-spaced-func */
 
 //==============================================================
 // This is an example of polling (reading) Holding Registers
@@ -7,33 +7,31 @@
 // until the previous action is completed (callback served).
 //==============================================================
 
-"use strict"
+"use strict";
 
 //==============================================================
 // create an empty modbus client
-var ModbusRTU   = require ('modbus-serial');
+var ModbusRTU   = require ("modbus-serial");
 var client      = new ModbusRTU();
 
-var mbsStatus   = 'Initializing...';    // holds a status of Modbus
+var mbsStatus   = "Initializing...";    // holds a status of Modbus
 
 // Modbus 'state' constants
-var MBS_STATE_INIT          = 'State init';
-var MBS_STATE_IDLE          = 'State idle';
-var MBS_STATE_NEXT          = 'State next';
-var MBS_STATE_GOOD_READ     = 'State good (read)';
-var MBS_STATE_FAIL_READ     = 'State fail (read)';
-var MBS_STATE_GOOD_CONNECT  = 'State good (port)';
-var MBS_STATE_FAIL_CONNECT  = 'State fail (port)';
+var MBS_STATE_INIT          = "State init";
+var MBS_STATE_IDLE          = "State idle";
+var MBS_STATE_NEXT          = "State next";
+var MBS_STATE_GOOD_READ     = "State good (read)";
+var MBS_STATE_FAIL_READ     = "State fail (read)";
+var MBS_STATE_GOOD_CONNECT  = "State good (port)";
+var MBS_STATE_FAIL_CONNECT  = 'State fail (port)";
 
 // Modbus TCP configuration values
 var mbsId       = 1;
 var mbsPort     = 502;
-//var mbsHost     = '10.8.0.4';
-var mbsHost     = '192.168.20.2';
+var mbsHost     = "192.168.20.2";
 var mbsScan     = 1000;
 var mbsTimeout  = 5000;
 var mbsState    = MBS_STATE_INIT;
-var mbsBufData;
 
 
 //==============================================================
@@ -51,7 +49,7 @@ var connectClient = function()
         .then(function()
         {
             mbsState  = MBS_STATE_GOOD_CONNECT;
-            mbsStatus = 'Connected, wait for reading...';
+            mbsStatus = "Connected, wait for reading...";
             console.log(mbsStatus);
         })
         .catch(function(e)
@@ -61,7 +59,7 @@ var connectClient = function()
             console.log(e);
         });
 
-}
+};
 
 
 //==============================================================
@@ -72,8 +70,7 @@ var readModbusData = function()
         .then(function(data)
         {
             mbsState   = MBS_STATE_GOOD_READ;
-            mbsStatus  = 'success';
-            mbsBufData = data.buffer.swap16();
+            mbsStatus  = "success";
             console.log(data.buffer);
         })
         .catch(function(e)
@@ -82,7 +79,7 @@ var readModbusData = function()
             mbsStatus = e.message;
             console.log(e);
         });
-}
+};
 
 
 //==============================================================
@@ -125,7 +122,7 @@ var runModbus = function()
     console.log(nextAction);
 
     // execute "next action" function if defined
-    if (nextAction != undefined)
+    if (nextAction !== undefined)
     {
         nextAction();
         mbsState = MBS_STATE_IDLE;
@@ -133,7 +130,7 @@ var runModbus = function()
 
     // set for next run
     setTimeout (runModbus, mbsScan);
-}
+};
 
 //==============================================================
 runModbus();


### PR DESCRIPTION
As requested in #240 , I have added framework examples of polling Modbus holding registers.

Please don't pay attention to multiple commits of the same files - I forgot to give a proper title/message, so I have committed (same) files again to be able to change the message (maybe there is an easier way, but I could not see it immediately).