### PR TITLE
Use callbacks in close() and destroy() even if nothing needs to be done

### DIFF
--- a/index.js
+++ b/index.js
@@ -380,6 +380,9 @@ ModbusRTU.prototype.close = function(callback) {
     if (this._port) {
         this._port.removeAllListeners("data");
         this._port.close(callback);
+    } else {
+        // nothing needed to be done
+        callback();
     }
 };
 
@@ -394,6 +397,9 @@ ModbusRTU.prototype.destroy = function(callback) {
     if (this._port && this._port.destroy) {
         this._port.removeAllListeners("data");
         this._port.destroy(callback);
+    } else {
+        // nothing needed to be done
+        callback();
     }
 };
 


### PR DESCRIPTION
In my code I call `close()` after getting an error to attempt a reconnect, but sometimes the port is already closed when this happens.  In this situation the callback never gets called, so my code freezes waiting forever for the port to close.

By calling the callback even when nothing needs to be done, the code will no longer get stuck.