### PR TITLE
Added support to concatenate multiple data events into one response

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ var ModbusRTU = require("modbus-serial");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-client.connectRTU("/dev/ttyUSB0", { baudRate: 9600 }, write);
+client.connectRTUBuffered("/dev/ttyUSB0", { baudRate: 9600 }, write);
 
 function write() {
     client.setID(1);

--- a/examples/buffer.js
+++ b/examples/buffer.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
+//client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/debug.js
+++ b/examples/debug.js
@@ -15,7 +15,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
+//client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -8,7 +8,7 @@ var client = new ModbusRTU();
 var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
 
 // open connection to a serial port
-client.connectRTU("/dev/ttyUSB0", { hupcl: false, dsrdtr: false })
+client.connectRTUBuffered("/dev/ttyUSB0", { hupcl: false, dsrdtr: false })
 //client.connectTCP("modbus.local", { port: 502 })
     .then(setClient)
     .then(function() {

--- a/examples/write.js
+++ b/examples/write.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-//client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
+//client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {

--- a/examples/write_complete.js
+++ b/examples/write_complete.js
@@ -6,7 +6,7 @@ var ModbusRTU = require("../index");
 var client = new ModbusRTU();
 
 // open connection to a serial port
-// client.connectRTU("/dev/ttyUSB0", {baudRate: 9600})
+// client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})
 client.connectTCP("127.0.0.1", { port: 8502 })
     .then(setClient)
     .then(function() {


### PR DESCRIPTION
I was running into a problem with low baud rates, where the serial port was splitting data at unexpected boundaries, so the `"data"` serial port event was firing multiple times with different pieces of what should be a single response.

Example as follows, with a bulk request for 61 registers over a 19200 baud connection.

```
TX Buffer(8) [13, 3, 32, 0, 0, 61, 143, 23]
RX  Buffer(23) [13, 3, 122, 0, 200, 27, 0, 0, 1, 0, 3, 0, 0, 0, 0, 4, 172, 0, 6, 0, 0, 7, 208]
RX  Buffer(31) [7, 218, 0, 249, 0, 248, 0, 0, 0, 0, 0, 0, 0, 0, 7, 208, 7, 218, 0, 249, 0, 248, 0, 0, 0, 0, 0, 0, 0, 0, 0]
RX  Buffer(31) [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255]
RX  Buffer(31) [255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 244, 37, 28, 0, 50, 32, 8, 38, 72, 0, 10, 0, 0, 12, 56, 32]
RX  Buffer(11) [10, 0, 0, 14, 251, 1, 94, 0, 18, 53, 254]
```

This change allows multiple data events to be concatenated together before processing. If the required data never arrives, a timeout is issued as normal.