### PR TITLE
Make recvBuffer part of the connection handler

### DIFF
--- a/servers/servertcp.js
+++ b/servers/servertcp.js
@@ -203,7 +203,6 @@ function _parseModbusBuffer(requestBuffer, vector, serverUnitID, sockWriter) {
 var ServerTCP = function(vector, options) {
     var modbus = this;
     options = options || {};
-    var recvBuffer = Buffer.from([]);
 
     // create a tcp server
     modbus._server = net.createServer();
@@ -221,6 +220,7 @@ var ServerTCP = function(vector, options) {
     modbus.socks = new Map();
 
     modbus._server.on("connection", function(sock) {
+        var recvBuffer = Buffer.from([]);
         modbus.socks.set(sock, 0);
 
         modbusSerialDebug({


### PR DESCRIPTION
Not sure if this is the correct fix or if it breaks other parts of the modbus server but here it goes.

When more than one client connect to ServerTCP, the recvBuffer gets mangled and thus render the server incapable of processing any further requests. The problem persists even after the clients close their connection.

You can reproduce the problem by:

1. run the sample server
2. connect with telnet and press enter 
3. close telnet
4. try to read a holding register with a modbus client
5. the client gets stuck there

With the proposed change the problem gets fixed for my cases.