### PR TITLE
Fix var i beeing used before assignment

### DIFF
--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -123,8 +123,8 @@ function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callbac
                 msg: "Invalid length"
             });
 
-        var cb = buildCb(i);
         var i = 0;
+        var cb = buildCb(i);
         var promiseOrValue = null;
 
         if (isGetCoil && vector.getCoil.length === 3) {


### PR DESCRIPTION
Hi,

In your last patch, you introduced a bug that breaks getCoil and getDiscreteInput functions of the TCP server by using a variable before assigning it.
This merge request fixes it