### PR TITLE
Allow TCP connections to originate from specific IP addresses

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -19,18 +19,25 @@ var CRC_LENGTH = 2;
  *
  * @param ip
  * @param options
+ *   options.port: Nonstandard Modbus port (default is 502).
+ *   options.localAddress: Local IP address to bind to, default is any.
+ *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
  * @constructor
  */
 var TcpPort = function(ip, options) {
     var modbus = this;
-    this.ip = ip;
     this.openFlag = false;
     this.callback = null;
     this._transactionIdWrite = 1;
 
     // options
     if (typeof(options) === "undefined") options = {};
-    this.port = options.port || MODBUS_PORT; // modbus port
+    this.connectOptions = {
+        host: ip,
+        port: options.port || MODBUS_PORT,
+        localAddress: options.localAddress,
+        family: options.family
+    };
 
     // handle callback - call a callback function only once, for the first event
     // it will triger
@@ -126,7 +133,7 @@ util.inherits(TcpPort, EventEmitter);
  */
 TcpPort.prototype.open = function(callback) {
     this.callback = callback;
-    this._client.connect(this.port, this.ip);
+    this._client.connect(this.connectOptions);
 };
 
 /**

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -23,18 +23,25 @@ var MODBUS_PORT = 502;
  *
  * @param {string} ip - ip address
  * @param {object} options - all options as JSON object
+ *   options.port: Nonstandard Modbus port (default is 502).
+ *   options.localAddress: Local IP address to bind to, default is any.
+ *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
  * @constructor
  */
 var TcpRTUBufferedPort = function(ip, options) {
     var modbus = this;
-    modbus.ip = ip;
     modbus.openFlag = false;
     modbus.callback = null;
     modbus._transactionIdWrite = 1;
 
     // options
     if (typeof options === "undefined") options = {};
-    modbus.port = options.port || MODBUS_PORT;
+    modbus.connectOptions = {
+        host: ip,
+        port: options.port || MODBUS_PORT,
+        localAddress: options.localAddress,
+        family: options.family || 0
+    };
 
     // internal buffer
     modbus._buffer = Buffer.alloc(0);
@@ -187,7 +194,7 @@ TcpRTUBufferedPort.prototype._emitData = function(start, length) {
  */
 TcpRTUBufferedPort.prototype.open = function(callback) {
     this.callback = callback;
-    this._client.connect(this.port, this.ip);
+    this._client.connect(this.connectOptions);
 };
 
 /**


### PR DESCRIPTION
We've got two Modbus programs running on the same machine, and they are both querying a Siemens PLC via Modbus TCP.  Unfortunately despite the Siemens device being brand new, it is running an extremely limited IP stack and if it gets multiple connections from the same IP address it drops all traffic.

The only solution is to ensure there is only one connection per IP address, which means we have to add two IP addresses to the machine, and then tell this library which IP address to use for outgoing packets.  This PR implements that feature.