### PR TITLE
Add debugging payload information to response data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,6 @@ function _readFC43(data, modbus, next) {
 function _writeBufferToPort(buffer, transactionId) {
     var transaction = this._transactions[transactionId];
 
-    this._port.write(buffer);
     if (transaction) {
         transaction._timeoutFired = false;
         transaction._timeoutHandle = _startTimeout(this._timeout, transaction);
@@ -221,6 +220,8 @@ function _writeBufferToPort(buffer, transactionId) {
             transaction.responses = [];
         }
     }
+
+    this._port.write(buffer);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -390,6 +390,10 @@ var ModbusRTU = function(port) {
     this._timeout = null; // timeout in msec before unanswered request throws timeout error
     this._unitID = 1;
 
+    // Flag to indicate whether debug mode (pass-through of raw
+    // request/response) is enabled.
+    this._debugEnabled = false;
+
     this._onReceive = _onReceive.bind(this);
 
     EventEmitter.call(this);
@@ -432,6 +436,21 @@ ModbusRTU.prototype.open = function(callback) {
         }
     });
 };
+
+
+/**
+ * Check if port debug mode is enabled
+ */
+Object.defineProperty(ModbusRTU.prototype, "isDebugEnabled", {
+    enumerable: true,
+    get: function() {
+        return this._debugEnabled;
+    },
+    set: function(enable) {
+        enable = Boolean(enable);
+        this._debugEnabled = enable;
+    }
+});
 
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -295,6 +295,47 @@ describe("ModbusRTU", function() {
                     done();
                 });
             });
+
+            it("should include raw payload data in response if debug enabled", function(done) {
+                /* This feature is common to _all_ function handlers. */
+                modbusRTU.isDebugEnabled = true;
+
+                modbusRTU.writeFC3(1, 8, 3, function(err, data) {
+                    modbusRTU.isDebugEnabled = false;
+
+                    expect(err).to.be.a("null");
+                    expect(data).to.have.property("request").with.length(8);
+                    expect(data.request.toString("hex")).to.equal("0103000800038409");
+
+                    expect(data).to.have.property("responses").with.length(1);
+                    expect(data.responses[0]).to.be.instanceof(Buffer).with.length(11);
+                    expect(data.responses[0].toString("hex")).to.equal("010306002a00800005f958");
+
+                    done();
+                });
+            });
+
+            it("should include raw payload data in exception if debug enabled", function(done) {
+                /* This feature is common to _all_ function handlers. */
+                modbusRTU.isDebugEnabled = true;
+
+                // Pretend Unit 3 sends buggy CRCs apparently.
+                modbusRTU.writeFC3(3, 8, 3, function(err, data) {
+                    modbusRTU.isDebugEnabled = false;
+
+                    expect(err).to.not.be.a("null");
+                    expect(err).to.have.property("modbusRequest").with.length(8);
+                    expect(err.modbusRequest.toString("hex")).to.equal("03030008000385eb");
+
+                    expect(err).to.have.property("modbusResponses").with.length(1);
+                    expect(err.modbusResponses[0]).to.be.instanceof(Buffer).with.length(11);
+                    expect(err.modbusResponses[0].toString("hex")).to.equal("030306002a00800005e138");
+
+                    expect(data).to.be.undefined;
+
+                    done();
+                });
+            });
         });
 
         describe("#writeFC5() - force one coil.", function() {


### PR DESCRIPTION
This optionally exposes the Modbus/RTU request and response payloads when the library caller sets the `isDebugEnabled` property of the `ModbusRTU` object to `true`.

This allows software to log raw frames for debugging by field engineers when troubleshooting issues such as CRC errors or framing issues.

Resolves issue #344.