### PR TITLE
Ensure unitID is integer

### DIFF
--- a/apis/promise.js
+++ b/apis/promise.js
@@ -65,7 +65,7 @@ var addPromiseAPI = function(Modbus) {
     var cl = Modbus.prototype;
 
     // set/get unitID
-    cl.setID = function(id) {this._unitID = +id;};
+    cl.setID = function(id) {this._unitID = Number(id);};
     cl.getID = function() {return this._unitID;};
 
     // set/get timeout

--- a/apis/promise.js
+++ b/apis/promise.js
@@ -65,7 +65,7 @@ var addPromiseAPI = function(Modbus) {
     var cl = Modbus.prototype;
 
     // set/get unitID
-    cl.setID = function(id) {this._unitID = id;};
+    cl.setID = function(id) {this._unitID = +id;};
     cl.getID = function() {return this._unitID;};
 
     // set/get timeout


### PR DESCRIPTION
Some clients might call something like `setID("1")` with a string instead of a number.
This then fails due to the strongly-typed comparison in `_onReceive()`
https://github.com/yaacov/node-modbus-serial/blob/0937df9eadb2a08c1ac5c90ceb2ec1017505bfe7/index.js#L370
So this PR casts `setID()` to a number.