### PR TITLE
fix: add Buffer input value to writeRegisters signature

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -45,7 +45,7 @@ export class ModbusRTU {
   writeCoil(dataAddress: number, state: boolean): Promise<WriteCoilResult>;
   writeCoils(dataAddress: number, states: Array<boolean>): Promise<WriteMultipleResult>;
   writeRegister(dataAddress: number, value: number): Promise<WriteRegisterResult>;
-  writeRegisters(dataAddress: number, values: Array<number>): Promise<WriteMultipleResult>; // 16
+  writeRegisters(dataAddress: number, values: Array<number> | Buffer): Promise<WriteMultipleResult>; // 16
   
   isOpen: boolean;
 }


### PR DESCRIPTION
Hello, function writeRegisters also accept buffer according to https://github.com/yaacov/node-modbus-serial/issues/303#issuecomment-554272039

I prepared fix to type definition file.