### PR TITLE
fix: remove listeners on tcp client when closing

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -143,8 +143,11 @@ TcpPort.prototype.open = function(callback) {
  * @param callback
  */
 TcpPort.prototype.close = function(callback) {
-    this.callback = callback;
-    this._client.end();
+    this._client.removeAllListeners();
+    this._client.end(function() {
+        modbus.emit("close");
+        callback()
+    );
 };
 
 /**


### PR DESCRIPTION
In my application It could be that I open/close client connection many times, I see many errors like: 

```
(node:6312) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Client]. Use emitter.setMaxListeners() to increase limit
```