### PR TITLE
Improve server callbacks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,7 @@
         "keyword-spacing": "off",
         "line-comment-position": "off",
         "linebreak-style": [
-            "error",
+            "off",
             "unix"
         ],
         "lines-around-comment": "off",

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -698,28 +698,7 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
             modbusErrorCode: 0x02, // Illegal address
             msg: "Invalid length"
         });
-
-    if (vector.setRegister) {
-        var value;
-
-        for (var i = 0; i < length; i++) {
-            var cb = buildCb(i);
-            value = requestBuffer.readUInt16BE(7 + i * 2);
-
-        try {
-                if (vector.setRegister.length === 4) {
-                    vector.setRegister(address + i, value, unitID, cb);
-            }
-            else {
-                    var promiseOrValue = vector.setRegister(address + i, value, unitID);
-                    _handlePromiseOrValue(promiseOrValue, cb);
-            }
-        }
-        catch (err) {
-            cb(err);
-        }
-        }
-    } else if (vector.setRegisterArray) {
+    if (vector.setRegisterArray) {
         value = [];
 
         for (i = 0; i < length; i++) {
@@ -729,12 +708,31 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
             _handlePromiseOrValue(value, cb);
         }
 
-            try {
-            if (vector.setRegisterArray.length === 6) {
+        try {
+            if (vector.setRegisterArray.length === 4) {
                 vector.setRegisterArray(address, value, unitID, cb);
+            }
+            else {
+                vector.setRegisterArray(address, value, unitID);
+            }
+        }
+        catch (err) {
+            cb(err);
+        }
+    } else if (vector.setRegister) {
+        var value;
+
+        for (var i = 0; i < length; i++) {
+            var cb = buildCb(i);
+            value = requestBuffer.readUInt16BE(7 + i * 2);
+
+            try {
+                if (vector.setRegister.length === 4) {
+                    vector.setRegister(address + i, value, unitID, cb);
                 }
                 else {
-                vector.setRegisterArray(address, value, unitID);
+                    var promiseOrValue = vector.setRegister(address + i, value, unitID);
+                    _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
             catch(err) {

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -601,28 +601,8 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
             msg: "Invalid length"
         });
 
-    if (vector.setCoil) {
-        var state;
-
-        for (var i = 0; i < length; i++) {
-            var cb = buildCb(i);
-            state = requestBuffer.readBit(i, 7);
-
-            try {
-                if (vector.setCoil.length === 4) {
-                    vector.setCoil(address + i, state !== false, unitID, cb);
-                }
-                else {
-                    var promiseOrValue = vector.setCoil(address + i, state !== false, unitID);
-                    _handlePromiseOrValue(promiseOrValue, cb);
-                }
-            }
-            catch(err) {
-                cb(err);
-            }
-        }
-    } else if (vector.setCoilArray) {
-        state = [];
+    if (vector.setCoilArray) {
+        var state = [];
 
         for (i = 0; i < length; i++) {
             cb = buildCb(i);
@@ -630,12 +610,31 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
             _handlePromiseOrValue(promiseOrValue, cb);
         }
 
-        try {
+            try {
             if (vector.setCoilArray.length === 4) {
                 vector.setCoilArray(address, state, unitID, cb);
+                }
+                else {
+                vector.setCoilArray(address, state, unitID);
+                }
+            }
+            catch(err) {
+                cb(err);
+            }
+    } else if (vector.setCoil) {
+        var state;
+
+        for (var i = 0; i < length; i++) {
+            var cb = buildCb(i);
+            state = requestBuffer.readBit(i, 7);
+
+        try {
+                if (vector.setCoil.length === 4) {
+                    vector.setCoil(address + i, state !== false, unitID, cb);
             }
             else {
-                vector.setCoilArray(address, state, unitID);
+                    var promiseOrValue = vector.setCoil(address + i, state !== false, unitID);
+                    _handlePromiseOrValue(promiseOrValue, cb);
             }
         }
         catch(err) {

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -255,7 +255,16 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
                 if (!err && values.length !== length) {
                     var error = new Error("Requested address length and response length do not match");
                     callback(error);
-                } else {
+                } else if (err) {
+                    var cb = buildCb(i);
+                    try {
+                        cb(err); //no need to use value array if there is an error
+                    }
+                    catch (ex) {
+                        cb(ex);
+                    }                    
+                }
+                else {
                     for (var i = 0; i < length; i++) {
                         var cb = buildCb(i);
                         try {
@@ -697,18 +706,18 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
             var cb = buildCb(i);
             value = requestBuffer.readUInt16BE(7 + i * 2);
 
-            try {
+        try {
                 if (vector.setRegister.length === 4) {
                     vector.setRegister(address + i, value, unitID, cb);
-                }
-                else {
+            }
+            else {
                     var promiseOrValue = vector.setRegister(address + i, value, unitID);
                     _handlePromiseOrValue(promiseOrValue, cb);
-                }
             }
-            catch(err) {
-                cb(err);
-            }
+        }
+        catch (err) {
+            cb(err);
+        }
         }
     } else if (vector.setRegisterArray) {
         value = [];
@@ -720,16 +729,17 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
             _handlePromiseOrValue(value, cb);
         }
 
-        try {
+            try {
             if (vector.setRegisterArray.length === 6) {
                 vector.setRegisterArray(address, value, unitID, cb);
-            }
-            else {
+                }
+                else {
                 vector.setRegisterArray(address, value, unitID);
+                }
             }
-        }
-        catch (err) {
-            cb(err);
+            catch(err) {
+                cb(err);
+            }
         }
     }
 }

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -557,7 +557,7 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
  * @returns undefined
  * @private
  */
-function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
+ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
     var address = requestBuffer.readUInt16BE(2);
     var length = requestBuffer.readUInt16BE(4);
 
@@ -610,17 +610,17 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
             _handlePromiseOrValue(promiseOrValue, cb);
         }
 
-            try {
+        try {
             if (vector.setCoilArray.length === 4) {
                 vector.setCoilArray(address, state, unitID, cb);
-                }
-                else {
+            }
+            else {
                 vector.setCoilArray(address, state, unitID);
-                }
             }
-            catch(err) {
-                cb(err);
-            }
+        }
+        catch(err) {
+            cb(err);
+        }
     } else if (vector.setCoil) {
         var state;
 
@@ -628,21 +628,21 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
             var cb = buildCb(i);
             state = requestBuffer.readBit(i, 7);
 
-        try {
+            try {
                 if (vector.setCoil.length === 4) {
                     vector.setCoil(address + i, state !== false, unitID, cb);
-            }
-            else {
+                }
+                else {
                     var promiseOrValue = vector.setCoil(address + i, state !== false, unitID);
                     _handlePromiseOrValue(promiseOrValue, cb);
+                }
+            }
+            catch(err) {
+                cb(err);
             }
         }
-        catch(err) {
-            cb(err);
-        }
-    }
+    } 
 }
-
 /**
  * Function to handle FC16 request.
  *

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -256,17 +256,17 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
                     var error = new Error("Requested address length and response length do not match");
                     callback(error);
                 } else if (err) {
-                    var cb = buildCb(i);
+                    const cb = buildCb(i);
                     try {
-                        cb(err); //no need to use value array if there is an error
+                        cb(err); // no need to use value array if there is an error
                     }
                     catch (ex) {
                         cb(ex);
-                    }                    
+                    }
                 }
                 else {
                     for (var i = 0; i < length; i++) {
-                        var cb = buildCb(i);
+                        const cb = buildCb(i);
                         try {
                             cb(err, values[i]);
                         }
@@ -557,7 +557,7 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
  * @returns undefined
  * @private
  */
- function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
+function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
     var address = requestBuffer.readUInt16BE(2);
     var length = requestBuffer.readUInt16BE(4);
 
@@ -622,7 +622,7 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
             cb(err);
         }
     } else if (vector.setCoil) {
-        var state;
+        let state;
 
         for (var i = 0; i < length; i++) {
             var cb = buildCb(i);
@@ -641,7 +641,7 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
                 cb(err);
             }
         }
-    } 
+    }
 }
 /**
  * Function to handle FC16 request.


### PR DESCRIPTION
Fixed issue #415 - [When returning error code from getMultipleHoldingRegisters, shouldn't need to pass values array to callback](https://github.com/yaacov/node-modbus-serial/issues/415 )

Also when _handleWriteMultipleRegisters was called, it checked for the presence of setRegister before setRegisterArray so it was impossible to build seperate handlers for both. This was corrected by changing the order.

Also there was an issue with the number of parameters a handler with a callback should have for setRegisterArray (6 vs 4)