### PR TITLE
Add missing returning types to ModbusRTU.d.ts

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -31,10 +31,10 @@ export class ModbusRTU {
   connectRTUBuffered(path: string, options: SerialPortOptions): Promise<void>;
   connectAsciiSerial(path: string, options: SerialPortOptions, next: Function): void;
   connectAsciiSerial(path: string, options: SerialPortOptions): Promise<void>;
-  linkTCP(socket: string, options: SerialPortOptions, next: Function);
-  linkTcpRTUBuffered(socket: string, options: TcpRTUPortOptions, next: Function);
-  linkTelnet(socket: string, options: TelnetPortOptions, next: Function);
-  connectRTUSocket(socket: string, next: Function);
+  linkTCP(socket: string, options: SerialPortOptions, next: Function): void;
+  linkTcpRTUBuffered(socket: string, options: TcpRTUPortOptions, next: Function): void;
+  linkTelnet(socket: string, options: TelnetPortOptions, next: Function): void;
+  connectRTUSocket(socket: string, next: Function): void;
 
   // Promise API
   setID(id: number): void;

--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -31,7 +31,7 @@ export class ModbusRTU {
   connectRTUBuffered(path: string, options: SerialPortOptions): Promise<void>;
   connectAsciiSerial(path: string, options: SerialPortOptions, next: Function): void;
   connectAsciiSerial(path: string, options: SerialPortOptions): Promise<void>;
-  linkTCP(socket: string, options: SerialPortOptions, next: Function): void;
+  linkTCP(socket: string, options: TcpPortOptions, next: Function): void;
   linkTcpRTUBuffered(socket: string, options: TcpRTUPortOptions, next: Function): void;
   linkTelnet(socket: string, options: TelnetPortOptions, next: Function): void;
   connectRTUSocket(socket: string, next: Function): void;
@@ -107,6 +107,7 @@ export interface TcpPortOptions {
   port?: number;
   localAddress?: string;
   family?: number;
+  ip?: string;
 }
 
 export interface UdpPortOptions {

--- a/apis/connection.js
+++ b/apis/connection.js
@@ -115,7 +115,7 @@ var addConnctionAPI = function(Modbus) {
      * Setup a communication port with existing socket, using TcpPort.
      *
      * @param {string} socket the instance of the net.Socket - required.
-     * @param {Object} options - the serial port options - optional.
+     * @param {Object} options - the TCP port options - optional.
      * @param {Function} next the function to call next.
      */
     cl.linkTCP = function(socket, options, next) {


### PR DESCRIPTION
Sorry I totally forgot the returning types of the missing definitions in last PR.

I also fix the type of linkTCP options.

Thank you :heart: 