### PR TITLE
#429 Correct function code table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This module has not been tested on every single version of NodeJS. For best resu
 | FC3 "Read Holding Registers" | `readHoldingRegisters(addr, len) ` |
 | FC4 "Read Input Registers" | `readInputRegisters(addr, len) ` |
 | FC5 "Force Single Coil" | `writeCoil(coil, binary) //NOT setCoil` |
-| FC6 "Preset Single Register"
-| FC15 "Force Multiple Coil" | `writeRegister(addr, value)` |
+| FC6 "Preset Single Register" | `writeRegister(addr, value)` |
+ | FC15 "Force Multiple Coil" | `writeCoils(addr, valueAry)` |
 | FC16 "Preset Multiple Registers" | `writeRegisters(addr, valueAry)` |
 | FC43/14 "Read Device Identification" (supported ports: TCP, RTU) | `readDeviceIdentification(id, obj)` |
 


### PR DESCRIPTION
The readme features a table with function codes and the respective function names. The entry for **FC6 "Preset Single Register"** was missing, and its function was erroneously placed in the following row for **FC15 "Force Multiple Coil"**. The correct function name for FC15 function was not present in the table and it has been corrected to be **writeCoils(addr, valueAry)**, similarly to **FC16 "Preset Multiple Registers"**.

This PR corrects the documentation.