### PR TITLE
Update ModbusRTU.d.ts

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -2,7 +2,7 @@ export class ModbusRTU {
   constructor(port?: any);
 
   open(callback: Function): void;
-  close(callback: Function): void;
+  close(callback?: Function): void;
 
   writeFC1(address: number, dataAddress: number, length: number, next: NodeStyleCallback<ReadCoilResult>): void;
   writeFC2(address: number, dataAddress: number, length: number, next: NodeStyleCallback<ReadCoilResult>): void;


### PR DESCRIPTION
According to the documentation, the callback param in the close method is optional.