### PR TITLE
Add timeout option to TcpPortOptions

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -108,6 +108,7 @@ export interface TcpPortOptions {
   localAddress?: string;
   family?: number;
   ip?: string;
+  timeout?: number;
 }
 
 export interface UdpPortOptions {


### PR DESCRIPTION
It looks like `timeout` is a supported option; this adds it to the TS definition