### PR TITLE
bump serialport dependency

### DIFF
--- a/apis/connection.js
+++ b/apis/connection.js
@@ -74,8 +74,8 @@ var addConnctionAPI = function(Modbus) {
         options.platformOptions = { vmin: MIN_MODBUSRTU_FRAMESZ, vtime: 0 };
 
         // create the SerialPort
-        var SerialPort = require("serialport");
-        this._port = new SerialPort(path, options);
+        var SerialPort = require("serialport").SerialPort;
+        this._port = new SerialPort(Object.assign({}, { path }, options));
 
         // open and call next
         return open(this, next);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "serialport": "^9.0.0"
+    "serialport": "^10.0.0"
   }
 }

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -4,7 +4,7 @@
 var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport");
+var SerialPort = require("serialport").SerialPort;
 var modbusSerialDebug = require("debug")("modbus-serial");
 
 var crc16 = require("../utils/crc16");
@@ -126,7 +126,7 @@ var AsciiPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client = new SerialPort(path, options);
+    this._client = new SerialPort(Object.assign({}, { path }, options));
 
     // register the port data event
     this._client.on("data", function(data) {

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -2,7 +2,7 @@
 var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport");
+var SerialPort = require("serialport").SerialPort;
 var modbusSerialDebug = require("debug")("modbus-serial");
 
 /* TODO: const should be set once, maybe */
@@ -70,7 +70,7 @@ var RTUBufferedPort = function(path, options) {
     this._length = 0;
 
     // create the SerialPort
-    this._client = new SerialPort(path, options);
+    this._client = new SerialPort(Object.assign({}, { path }, options));
 
     // attach an error listner on the SerialPort object
     this._client.on("error", function(error) {

--- a/test/mocks/SerialPortMock.js
+++ b/test/mocks/SerialPortMock.js
@@ -7,7 +7,7 @@ var EventEmitter = events.EventEmitter || events;
 /**
  * Mock for SerialPort
  */
-var SerialPortMock = function(path, options, callback) {
+var SerialPortMock = function(options, callback) {
     EventEmitter.call(this);
     this._openFlag = false;
     if (callback) {
@@ -50,4 +50,4 @@ SerialPortMock.prototype.receive = function(buffer) {
     this.emit("data", buffer);
 };
 
-module.exports = SerialPortMock;
+module.exports = { SerialPort: SerialPortMock };


### PR DESCRIPTION
Reference to [serialport@10.0.0](https://github.com/serialport/node-serialport/releases/tag/%40serialport%2Fbindings%4010.0.0)

It's a savior version of serialport for people who are using Electron, and I hope we can upgrade the dependency for everyone use.

I tested a few RTU functions in my local machine with a USB serial-port-to-modbus device plugged in, not very much. I was using Electron 13, and didn't test release yet. The unit tests has passed.

Let me know if I am supposed to improve some of this pull prequest. :heart: 