### PR TITLE
Convert to native class syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ require("./utils/buffer_bit")();
 var crc16 = require("./utils/crc16");
 var modbusSerialDebug = require("debug")("modbus-serial");
 
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 
@@ -462,558 +461,545 @@ function _onError(e) {
     this.emit("error", err);
 }
 
-/**
- * Class making ModbusRTU calls fun and easy.
- *
- * @param {SerialPort} port the serial port to use.
- */
-var ModbusRTU = function(port) {
-    // the serial port to use
-    this._port = port;
+class ModbusRTU extends EventEmitter {
+    /**
+     * Class making ModbusRTU calls fun and easy.
+     *
+     * @param {SerialPort} port the serial port to use.
+     */
+    constructor(port) {
+        super();
 
-    // state variables
-    this._transactions = {};
-    this._timeout = null; // timeout in msec before unanswered request throws timeout error
-    this._unitID = 1;
+        // the serial port to use
+        this._port = port;
 
-    // Flag to indicate whether debug mode (pass-through of raw
-    // request/response) is enabled.
-    this._debugEnabled = false;
+        // state variables
+        this._transactions = {};
+        this._timeout = null; // timeout in msec before unanswered request throws timeout error
+        this._unitID = 1;
 
-    this._onReceive = _onReceive.bind(this);
-    this._onError = _onError.bind(this);
+        // Flag to indicate whether debug mode (pass-through of raw
+        // request/response) is enabled.
+        this._debugEnabled = false;
 
-    EventEmitter.call(this);
-};
-util.inherits(ModbusRTU, EventEmitter);
+        this._onReceive = _onReceive.bind(this);
+        this._onError = _onError.bind(this);
+    }
 
-/**
- * Open the serial port and register Modbus parsers
- *
- * @param {Function} callback the function to call next on open success
- *      of failure.
- */
-ModbusRTU.prototype.open = function(callback) {
-    var modbus = this;
+    /**
+     * Open the serial port and register Modbus parsers
+     *
+     * @param {Function} callback the function to call next on open success
+     *      of failure.
+     */
+    open(callback) {
+        var modbus = this;
 
-    // open the serial port
-    modbus._port.open(function(error) {
-        if (error) {
-            modbusSerialDebug({ action: "port open error", error: error });
-            /* On serial port open error call next function */
-            if (callback)
-                callback(error);
-        } else {
-            /* init ports transaction id and counter */
-            modbus._port._transactionIdRead = 1;
-            modbus._port._transactionIdWrite = 1;
+        // open the serial port
+        modbus._port.open(function(error) {
+            if (error) {
+                modbusSerialDebug({ action: "port open error", error: error });
+                /* On serial port open error call next function */
+                if (callback)
+                    callback(error);
+            } else {
+                /* init ports transaction id and counter */
+                modbus._port._transactionIdRead = 1;
+                modbus._port._transactionIdWrite = 1;
 
-            /* On serial port success
-             * (re-)register the modbus parser functions
-             */
-            modbus._port.removeListener("data", modbus._onReceive);
-            modbus._port.on("data", modbus._onReceive);
+                /* On serial port success
+                 * (re-)register the modbus parser functions
+                 */
+                modbus._port.removeListener("data", modbus._onReceive);
+                modbus._port.on("data", modbus._onReceive);
 
-            /* On serial port error
-             * (re-)register the error listner function
-             */
-            modbus._port.removeListener("error", modbus._onError);
-            modbus._port.on("error", modbus._onError);
+                /* On serial port error
+                 * (re-)register the error listner function
+                 */
+                modbus._port.removeListener("error", modbus._onError);
+                modbus._port.on("error", modbus._onError);
 
-            /* Hook the close event so we can relay it to our callers. */
-            modbus._port.once("close", modbus.emit.bind(modbus, "close"));
+                /* Hook the close event so we can relay it to our callers. */
+                modbus._port.once("close", modbus.emit.bind(modbus, "close"));
 
-            /* On serial port open OK call next function with no error */
-            if (callback)
-                callback(error);
-        }
-    });
-};
+                /* On serial port open OK call next function with no error */
+                if (callback)
+                    callback(error);
+            }
+        });
+    }
 
-
-/**
- * Check if port debug mode is enabled
- */
-Object.defineProperty(ModbusRTU.prototype, "isDebugEnabled", {
-    enumerable: true,
-    get: function() {
+    get isDebugEnabled() {
         return this._debugEnabled;
-    },
-    set: function(enable) {
+    }
+
+    set isDebugEnabled(enable) {
         enable = Boolean(enable);
         this._debugEnabled = enable;
     }
-});
 
-
-/**
- * Check if port is open
- */
-Object.defineProperty(ModbusRTU.prototype, "isOpen", {
-    enumerable: true,
-    get: function() {
+    get isOpen() {
         if (this._port) {
             return this._port.isOpen;
         }
 
         return false;
     }
-});
 
-
-/**
- * Close the serial port
- *
- * @param {Function} callback the function to call next on close success
- *      or failure.
- */
-ModbusRTU.prototype.close = function(callback) {
-    // close the serial port if exist
-    if (this._port) {
-        this._port.removeAllListeners("data");
-        this._port.close(callback);
-    } else {
-        // nothing needed to be done
-        callback();
-    }
-};
-
-/**
- * Destory the serial port
- *
- * @param {Function} callback the function to call next on close success
- *      or failure.
- */
-ModbusRTU.prototype.destroy = function(callback) {
-    // close the serial port if exist and it has a destroy function
-    if (this._port && this._port.destroy) {
-        this._port.removeAllListeners("data");
-        this._port.destroy(callback);
-    } else {
-        // nothing needed to be done
-        callback();
-    }
-};
-
-/**
- * Write a Modbus "Read Coil Status" (FC=01) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first coil.
- * @param {number} length the total number of coils requested.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC1 = function(address, dataAddress, length, next) {
-    this.writeFC2(address, dataAddress, length, next, 1);
-};
-
-/**
- * Write a Modbus "Read Input Status" (FC=02) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first digital input.
- * @param {number} length the total number of digital inputs requested.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC2 = function(address, dataAddress, length, next, code) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    // function code defaults to 2
-    code = code || 2;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 3 + parseInt((length - 1) / 8 + 1) + 2,
-        next: next
-    };
-
-    var codeLength = 6;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-    buf.writeUInt16BE(length, 4);
-
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Read Holding Registers" (FC=03) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first register.
- * @param {number} length the total number of registers requested.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC3 = function(address, dataAddress, length, next) {
-    this.writeFC4(address, dataAddress, length, next, 3);
-};
-
-/**
- * Write a Modbus "Read Input Registers" (FC=04) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first register.
- * @param {number} length the total number of registers requested.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC4 = function(address, dataAddress, length, next, code) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    // function code defaults to 4
-    code = code || 4;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 3 + 2 * length + 2,
-        next: next
-    };
-
-    var codeLength = 6;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-    buf.writeUInt16BE(length, 4);
-
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Force Single Coil" (FC=05) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the coil.
- * @param {number} state the boolean state to write to the coil (true / false).
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC5 = function(address, dataAddress, state, next) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    var code = 5;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 8,
-        next: next
-    };
-
-    var codeLength = 6;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-
-    if (state) {
-        buf.writeUInt16BE(0xff00, 4);
-    } else {
-        buf.writeUInt16BE(0x0000, 4);
-    }
-
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Preset Single Register " (FC=6) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the register.
- * @param {number} value the value to write to the register.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC6 = function(address, dataAddress, value, next) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    var code = 6;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 8,
-        next: next
-    };
-
-    var codeLength = 6; // 1B deviceAddress + 1B functionCode + 2B dataAddress + 2B value
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-
-    if (Buffer.isBuffer(value)) {
-        value.copy(buf, 4);
-    } else {
-        buf.writeUInt16BE(value, 4);
-    }
-
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Force Multiple Coils" (FC=15) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first coil.
- * @param {Array} array the array of boolean states to write to coils.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC15 = function(address, dataAddress, array, next) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    var code = 15;
-    var i = 0;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 8,
-        next: next
-    };
-
-    var dataBytes = Math.ceil(array.length / 8);
-    var codeLength = 7 + dataBytes;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-    buf.writeUInt16BE(array.length, 4);
-    buf.writeUInt8(dataBytes, 6);
-
-    // clear the data bytes before writing bits data
-    for (i = 0; i < dataBytes; i++) {
-        buf.writeUInt8(0, 7 + i);
-    }
-
-    for (i = 0; i < array.length; i++) {
-        // buffer bits are already all zero (0)
-        // only set the ones set to one (1)
-        if (array[i]) {
-            buf.writeBit(1, i, 7);
+    /**
+     * Close the serial port
+     *
+     * @param {Function} callback the function to call next on close success
+     *      or failure.
+     */
+    close(callback) {
+        // close the serial port if exist
+        if (this._port) {
+            this._port.removeAllListeners("data");
+            this._port.close(callback);
+        } else {
+            // nothing needed to be done
+            callback();
         }
     }
 
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Preset Multiple Registers" (FC=16) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} dataAddress the Data Address of the first register.
- * @param {Array} array the array of values to write to registers.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC16 = function(address, dataAddress, array, next) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-
-    // sanity check
-    if (typeof address === "undefined" || typeof dataAddress === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-
-    var code = 16;
-
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        nextLength: 8,
-        next: next
-    };
-
-    var dataLength = array.length;
-    if (Buffer.isBuffer(array)) {
-        // if array is a buffer it has double length
-        dataLength = array.length / 2;
-    }
-
-    var codeLength = 7 + 2 * dataLength;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt16BE(dataAddress, 2);
-    buf.writeUInt16BE(dataLength, 4);
-    buf.writeUInt8(dataLength * 2, 6);
-
-    // copy content of array to buf
-    if (Buffer.isBuffer(array)) {
-        array.copy(buf, 7);
-    } else {
-        for (var i = 0; i < dataLength; i++) {
-            buf.writeUInt16BE(array[i], 7 + 2 * i);
+    /**
+     * Destory the serial port
+     *
+     * @param {Function} callback the function to call next on close success
+     *      or failure.
+     */
+    destroy(callback) {
+        // close the serial port if exist and it has a destroy function
+        if (this._port && this._port.destroy) {
+            this._port.removeAllListeners("data");
+            this._port.destroy(callback);
+        } else {
+            // nothing needed to be done
+            callback();
         }
     }
 
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write  mODBUS "Read Device Identification" (FC=20) to serial port
- * @param {number} address the slave unit address.
- * @param {Function} next;
- */
-ModbusRTU.prototype.writeFC20 = function(address, fileNumber, recordNumber, next) {
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
-    }
-    // sanity check
-    if (typeof address === "undefined") {
-        if (next) next(new BadAddressError());
-        return;
-    }
-    // function code defaults to 20
-    var code = 20;
-    var codeLength = 10;
-    var byteCount = 7;
-    var chunck = 100;
-
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        lengthUnknown: true,
-        next: next
-    };
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt8(byteCount, 2);
-    buf.writeUInt8(6, 3); // ReferenceType
-    buf.writeUInt16BE(fileNumber, 4);
-    buf.writeUInt16BE(recordNumber, 6);
-    buf.writeUInt8(chunck, 9);
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
-
-/**
- * Write a Modbus "Read Device Identification" (FC=43) to serial port.
- *
- * @param {number} address the slave unit address.
- * @param {number} deviceIdCode the read device access code.
- * @param {number} objectId the array of values to write to registers.
- * @param {Function} next the function to call next.
- */
-ModbusRTU.prototype.writeFC43 = function(address, deviceIdCode, objectId, next) {
-    // check port is actually open before attempting write
-    if (this.isOpen !== true) {
-        if (next) next(new PortNotOpenError());
-        return;
+    /**
+     * Write a Modbus "Read Coil Status" (FC=01) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first coil.
+     * @param {number} length the total number of coils requested.
+     * @param {Function} next the function to call next.
+     */
+    writeFC1(address, dataAddress, length, next) {
+        this.writeFC2(address, dataAddress, length, next, 1);
     }
 
-    var code = 0x2B; // 43
+    /**
+     * Write a Modbus "Read Input Status" (FC=02) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first digital input.
+     * @param {number} length the total number of digital inputs requested.
+     * @param {Function} next the function to call next.
+     */
+    writeFC2(address, dataAddress, length, next, code) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
 
-    // set state variables
-    this._transactions[this._port._transactionIdWrite] = {
-        nextAddress: address,
-        nextCode: code,
-        lengthUnknown: true,
-        next: next
-    };
-    var codeLength = 5;
-    var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
-    buf.writeUInt8(address, 0);
-    buf.writeUInt8(code, 1);
-    buf.writeUInt8(0x0E, 2); // 16 MEI Type
-    buf.writeUInt8(deviceIdCode, 3);
-    buf.writeUInt8(objectId, 4);
-    // add crc bytes to buffer
-    buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
-    // write buffer to serial port
-    _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
-};
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        // function code defaults to 2
+        code = code || 2;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 3 + parseInt((length - 1) / 8 + 1) + 2,
+            next: next
+        };
+
+        var codeLength = 6;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+        buf.writeUInt16BE(length, 4);
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Read Holding Registers" (FC=03) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first register.
+     * @param {number} length the total number of registers requested.
+     * @param {Function} next the function to call next.
+     */
+    writeFC3(address, dataAddress, length, next) {
+        this.writeFC4(address, dataAddress, length, next, 3);
+    }
+
+    /**
+     * Write a Modbus "Read Input Registers" (FC=04) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first register.
+     * @param {number} length the total number of registers requested.
+     * @param {Function} next the function to call next.
+     */
+    writeFC4(address, dataAddress, length, next, code) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        // function code defaults to 4
+        code = code || 4;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 3 + 2 * length + 2,
+            next: next
+        };
+
+        var codeLength = 6;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+        buf.writeUInt16BE(length, 4);
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Force Single Coil" (FC=05) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the coil.
+     * @param {number} state the boolean state to write to the coil (true / false).
+     * @param {Function} next the function to call next.
+     */
+    writeFC5(address, dataAddress, state, next) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        var code = 5;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 8,
+            next: next
+        };
+
+        var codeLength = 6;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+
+        if (state) {
+            buf.writeUInt16BE(0xff00, 4);
+        } else {
+            buf.writeUInt16BE(0x0000, 4);
+        }
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Preset Single Register " (FC=6) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the register.
+     * @param {number} value the value to write to the register.
+     * @param {Function} next the function to call next.
+     */
+    writeFC6(address, dataAddress, value, next) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        var code = 6;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 8,
+            next: next
+        };
+
+        var codeLength = 6; // 1B deviceAddress + 1B functionCode + 2B dataAddress + 2B value
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+
+        if (Buffer.isBuffer(value)) {
+            value.copy(buf, 4);
+        } else {
+            buf.writeUInt16BE(value, 4);
+        }
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Force Multiple Coils" (FC=15) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first coil.
+     * @param {Array} array the array of boolean states to write to coils.
+     * @param {Function} next the function to call next.
+     */
+    writeFC15(address, dataAddress, array, next) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        var code = 15;
+        var i = 0;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 8,
+            next: next
+        };
+
+        var dataBytes = Math.ceil(array.length / 8);
+        var codeLength = 7 + dataBytes;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+        buf.writeUInt16BE(array.length, 4);
+        buf.writeUInt8(dataBytes, 6);
+
+        // clear the data bytes before writing bits data
+        for (i = 0; i < dataBytes; i++) {
+            buf.writeUInt8(0, 7 + i);
+        }
+
+        for (i = 0; i < array.length; i++) {
+            // buffer bits are already all zero (0)
+            // only set the ones set to one (1)
+            if (array[i]) {
+                buf.writeBit(1, i, 7);
+            }
+        }
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Preset Multiple Registers" (FC=16) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} dataAddress the Data Address of the first register.
+     * @param {Array} array the array of values to write to registers.
+     * @param {Function} next the function to call next.
+     */
+    writeFC16(address, dataAddress, array, next) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        // sanity check
+        if (typeof address === "undefined" || typeof dataAddress === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+
+        var code = 16;
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            nextLength: 8,
+            next: next
+        };
+
+        var dataLength = array.length;
+        if (Buffer.isBuffer(array)) {
+            // if array is a buffer it has double length
+            dataLength = array.length / 2;
+        }
+
+        var codeLength = 7 + 2 * dataLength;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt16BE(dataAddress, 2);
+        buf.writeUInt16BE(dataLength, 4);
+        buf.writeUInt8(dataLength * 2, 6);
+
+        // copy content of array to buf
+        if (Buffer.isBuffer(array)) {
+            array.copy(buf, 7);
+        } else {
+            for (var i = 0; i < dataLength; i++) {
+                buf.writeUInt16BE(array[i], 7 + 2 * i);
+            }
+        }
+
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write  mODBUS "Read Device Identification" (FC=20) to serial port
+     * @param {number} address the slave unit address.
+     * @param {Function} next;
+     */
+    writeFC20(address, fileNumber, recordNumber, next) {
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+        // sanity check
+        if (typeof address === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+        // function code defaults to 20
+        var code = 20;
+        var codeLength = 10;
+        var byteCount = 7;
+        var chunck = 100;
+
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            lengthUnknown: true,
+            next: next
+        };
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt8(byteCount, 2);
+        buf.writeUInt8(6, 3); // ReferenceType
+        buf.writeUInt16BE(fileNumber, 4);
+        buf.writeUInt16BE(recordNumber, 6);
+        buf.writeUInt8(chunck, 9);
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Read Device Identification" (FC=43) to serial port.
+     *
+     * @param {number} address the slave unit address.
+     * @param {number} deviceIdCode the read device access code.
+     * @param {number} objectId the array of values to write to registers.
+     * @param {Function} next the function to call next.
+     */
+    writeFC43(address, deviceIdCode, objectId, next) {
+        // check port is actually open before attempting write
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+
+        var code = 0x2B; // 43
+
+        // set state variables
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            lengthUnknown: true,
+            next: next
+        };
+        var codeLength = 5;
+        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt8(0x0E, 2); // 16 MEI Type
+        buf.writeUInt8(deviceIdCode, 3);
+        buf.writeUInt8(objectId, 4);
+        // add crc bytes to buffer
+        buf.writeUInt16LE(crc16(buf.slice(0, -2)), codeLength);
+        // write buffer to serial port
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+}
 
 // add the connection shorthand API
 require("./apis/connection")(ModbusRTU);

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -1,5 +1,4 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var dgram = require("dgram");
@@ -33,186 +32,185 @@ function _checkData(modbus, buf) {
         crcIn === crc16(buf.slice(0, -2)));
 }
 
-/**
- * Simulate a modbus-RTU port using C701 UDP-to-Serial bridge.
- *
- * @param ip
- * @param options
- * @constructor
- */
-var UdpPort = function(ip, options) {
-    var modbus = this;
-    this.ip = ip;
-    this.openFlag = false;
+class UdpPort extends EventEmitter {
+    /**
+     * Simulate a modbus-RTU port using C701 UDP-to-Serial bridge.
+     *
+     * @param ip
+     * @param options
+     * @constructor
+     */
+    constructor(ip, options) {
+        super();
 
-    // options
-    if (typeof(options) === "undefined") options = {};
-    this.port = options.port || C701_PORT; // C701 port
+        var modbus = this;
+        this.ip = ip;
+        this.openFlag = false;
 
-    // create a socket
-    this._client = dgram.createSocket("udp4");
+        // options
+        if (typeof(options) === "undefined") options = {};
+        this.port = options.port || C701_PORT; // C701 port
 
-    // wait for answer
-    this._client.on("message", function(data) {
-        var buffer = null;
+        // create a socket
+        this._client = dgram.createSocket("udp4");
 
-        // check expected length
-        if (modbus.length < 6) return;
+        // wait for answer
+        this._client.on("message", function(data) {
+            var buffer = null;
 
-        // check message length
-        if (data.length < (116 + 5)) return;
+            // check expected length
+            if (modbus.length < 6) return;
 
-        // check the C701 packet magic
-        if (data.readUInt16LE(2) !== 602) return;
+            // check message length
+            if (data.length < (116 + 5)) return;
 
-        // check for modbus valid answer
-        // get the serial data from the C701 packet
-        buffer = data.slice(data.length - modbus._length);
+            // check the C701 packet magic
+            if (data.readUInt16LE(2) !== 602) return;
 
-        modbusSerialDebug({ action: "receive c701 upd port", data: data, buffer: buffer });
-        modbusSerialDebug(JSON.stringify({ action: "receive c701 upd port strings", data: data, buffer: buffer }));
-
-        // check the serial data
-        if (_checkData(modbus, buffer)) {
-            modbusSerialDebug({ action: "emit data serial rtu buffered port", buffer: buffer });
-            modbusSerialDebug(JSON.stringify({ action: "emit data serial rtu buffered port strings", buffer: buffer }));
-
-            modbus.emit("data", buffer);
-        } else {
-            // check for modbus exception
+            // check for modbus valid answer
             // get the serial data from the C701 packet
-            buffer = data.slice(data.length - 5);
+            buffer = data.slice(data.length - modbus._length);
+
+            modbusSerialDebug({ action: "receive c701 upd port", data: data, buffer: buffer });
+            modbusSerialDebug(JSON.stringify({ action: "receive c701 upd port strings", data: data, buffer: buffer }));
 
             // check the serial data
             if (_checkData(modbus, buffer)) {
                 modbusSerialDebug({ action: "emit data serial rtu buffered port", buffer: buffer });
-                modbusSerialDebug(JSON.stringify({
-                    action: "emit data serial rtu buffered port strings",
-                    buffer: buffer
-                }));
+                modbusSerialDebug(JSON.stringify({ action: "emit data serial rtu buffered port strings", buffer: buffer }));
 
                 modbus.emit("data", buffer);
+            } else {
+                // check for modbus exception
+                // get the serial data from the C701 packet
+                buffer = data.slice(data.length - 5);
+
+                // check the serial data
+                if (_checkData(modbus, buffer)) {
+                    modbusSerialDebug({ action: "emit data serial rtu buffered port", buffer: buffer });
+                    modbusSerialDebug(JSON.stringify({
+                        action: "emit data serial rtu buffered port strings",
+                        buffer: buffer
+                    }));
+
+                    modbus.emit("data", buffer);
+                }
             }
-        }
-    });
+        });
 
-    this._client.on("listening", function() {
-        modbus.openFlag = true;
-    });
+        this._client.on("listening", function() {
+            modbus.openFlag = true;
+        });
 
-    this._client.on("close", function() {
-        modbus.openFlag = false;
-    });
+        this._client.on("close", function() {
+            modbus.openFlag = false;
+        });
+    }
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this.openFlag;
+    get isOpen() {
+        return this.openFlag;
+    }
+
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    // eslint-disable-next-line class-methods-use-this
+    open(callback) {
+        if (callback)
+            callback(null);
+    }
+
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
+        this._client.close();
+        if (callback)
+            callback(null);
+    }
+
+    /**
+     * Send data to a modbus-tcp slave.
+     *
+     * @param data
+     */
+    write(data) {
+        if(data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
+            return;
         }
-    });
 
-    EventEmitter.call(this);
-};
-util.inherits(UdpPort, EventEmitter);
+        var length = null;
 
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-UdpPort.prototype.open = function(callback) {
-    if (callback)
-        callback(null);
-};
+        // remember current unit and command
+        this._id = data[0];
+        this._cmd = data[1];
 
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-UdpPort.prototype.close = function(callback) {
-    this._client.close();
-    if (callback)
-        callback(null);
-};
+        // calculate expected answer length
+        switch (this._cmd) {
+            case 1:
+            case 2:
+                length = data.readUInt16BE(4);
+                this._length = 3 + parseInt((length - 1) / 8 + 1) + 2;
+                break;
+            case 3:
+            case 4:
+                length = data.readUInt16BE(4);
+                this._length = 3 + 2 * length + 2;
+                break;
+            case 5:
+            case 6:
+            case 15:
+            case 16:
+                this._length = 6 + 2;
+                break;
+            default:
+                // raise and error ?
+                this._length = 0;
+                break;
+        }
 
-/**
- * Send data to a modbus-tcp slave.
- *
- * @param data
- */
-UdpPort.prototype.write = function(data) {
-    if(data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
-        return;
+        // build C701 header
+        var buffer = Buffer.alloc(data.length + 116);
+        buffer.fill(0);
+        buffer.writeUInt16LE(600, 2);           // C701 magic for serial bridge
+        buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
+        buffer.writeUInt16LE(this._length, 38); // expected serial answer length
+        buffer.writeUInt16LE(1, 102);           // C7011 RS481 hub (1..2)
+        buffer.writeUInt16LE(data.length, 104); // serial data length
+
+        // add serial line data
+        data.copy(buffer, 116);
+
+        // send buffer to C701 UDP to serial bridge
+        this._client.send(buffer, 0, buffer.length, this.port, this.ip);
+
+        modbusSerialDebug({
+            action: "send c701 upd port",
+            data: data,
+            buffer: buffer,
+            unitid: this._id,
+            functionCode: this._cmd
+        });
+
+        modbusSerialDebug(JSON.stringify({
+            action: "send c701 upd port strings",
+            data: data,
+            buffer: buffer,
+            unitid: this._id,
+            functionCode: this._cmd
+        }));
     }
-
-    var length = null;
-
-    // remember current unit and command
-    this._id = data[0];
-    this._cmd = data[1];
-
-    // calculate expected answer length
-    switch (this._cmd) {
-        case 1:
-        case 2:
-            length = data.readUInt16BE(4);
-            this._length = 3 + parseInt((length - 1) / 8 + 1) + 2;
-            break;
-        case 3:
-        case 4:
-            length = data.readUInt16BE(4);
-            this._length = 3 + 2 * length + 2;
-            break;
-        case 5:
-        case 6:
-        case 15:
-        case 16:
-            this._length = 6 + 2;
-            break;
-        default:
-            // raise and error ?
-            this._length = 0;
-            break;
-    }
-
-    // build C701 header
-    var buffer = Buffer.alloc(data.length + 116);
-    buffer.fill(0);
-    buffer.writeUInt16LE(600, 2);           // C701 magic for serial bridge
-    buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
-    buffer.writeUInt16LE(this._length, 38); // expected serial answer length
-    buffer.writeUInt16LE(1, 102);           // C7011 RS481 hub (1..2)
-    buffer.writeUInt16LE(data.length, 104); // serial data length
-
-    // add serial line data
-    data.copy(buffer, 116);
-
-    // send buffer to C701 UDP to serial bridge
-    this._client.send(buffer, 0, buffer.length, this.port, this.ip);
-
-    modbusSerialDebug({
-        action: "send c701 upd port",
-        data: data,
-        buffer: buffer,
-        unitid: this._id,
-        functionCode: this._cmd
-    });
-
-    modbusSerialDebug(JSON.stringify({
-        action: "send c701 upd port strings",
-        data: data,
-        buffer: buffer,
-        unitid: this._id,
-        functionCode: this._cmd
-    }));
-};
+}
 
 /**
  * UDP port for Modbus.

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -1,5 +1,4 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var net = require("net");
@@ -14,215 +13,213 @@ var MIN_DATA_LENGTH = 6;
 var MIN_MBAP_LENGTH = 6;
 var CRC_LENGTH = 2;
 
-/**
- * Simulate a modbus-RTU port using modbus-TCP connection.
- *
- * @param ip
- * @param options
- *   options.port: Nonstandard Modbus port (default is 502).
- *   options.localAddress: Local IP address to bind to, default is any.
- *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
- * @constructor
- */
-var TcpPort = function(ip, options) {
-    var modbus = this;
-    this.openFlag = false;
-    this.callback = null;
-    this._transactionIdWrite = 1;
-    this._externalSocket = null;
+class TcpPort extends EventEmitter {
+    /**
+     * Simulate a modbus-RTU port using modbus-TCP connection.
+     *
+     * @param ip
+     * @param options
+     *   options.port: Nonstandard Modbus port (default is 502).
+     *   options.localAddress: Local IP address to bind to, default is any.
+     *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
+     * @constructor
+     */
+    constructor(ip, options) {
+        super();
 
-    if(typeof ip === "object") {
-        options = ip;
+        var modbus = this;
+        this.openFlag = false;
+        this.callback = null;
+        this._transactionIdWrite = 1;
+        this._externalSocket = null;
+
+        if(typeof ip === "object") {
+            options = ip;
+        }
+
+        if (typeof(options) === "undefined") options = {};
+
+        this.connectOptions = {
+            host: ip || options.ip,
+            port: options.port || MODBUS_PORT,
+            localAddress: options.localAddress,
+            family: options.family
+        };
+
+        if(options.socket) {
+            if(options.socket instanceof net.Socket) {
+                this._externalSocket = options.socket;
+                this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
+            } else {
+                throw new Error("invalid socket provided");
+            }
+        }
+
+        // handle callback - call a callback function only once, for the first event
+        // it will triger
+        var handleCallback = function(had_error) {
+            if (modbus.callback) {
+                modbus.callback(had_error);
+                modbus.callback = null;
+            }
+        };
+
+        // init a socket
+        this._client = this._externalSocket || new net.Socket();
+
+        if (options.timeout) this._client.setTimeout(options.timeout);
+        this._client.on("data", function(data) {
+            var buffer;
+            var crc;
+            var length;
+
+            // data recived
+            modbusSerialDebug({ action: "receive tcp port strings", data: data });
+
+            // check data length
+            while (data.length > MIN_MBAP_LENGTH) {
+                // parse tcp header length
+                length = data.readUInt16BE(4);
+
+                // cut 6 bytes of mbap and copy pdu
+                buffer = Buffer.alloc(length + CRC_LENGTH);
+                data.copy(buffer, 0, MIN_MBAP_LENGTH);
+
+                // add crc to message
+                crc = crc16(buffer.slice(0, -CRC_LENGTH));
+                buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
+
+                // update transaction id and emit data
+                modbus._transactionIdRead = data.readUInt16BE(0);
+                modbus.emit("data", buffer);
+
+                // debug
+                modbusSerialDebug({ action: "parsed tcp port", buffer: buffer, transactionId: modbus._transactionIdRead });
+
+                // reset data
+                data = data.slice(length + MIN_MBAP_LENGTH);
+            }
+        });
+
+        this._client.on("connect", function() {
+            modbus.openFlag = true;
+            modbusSerialDebug("TCP port: signal connect");
+            handleCallback();
+        });
+
+        this._client.on("close", function(had_error) {
+            modbus.openFlag = false;
+            modbusSerialDebug("TCP port: signal close: " + had_error);
+            handleCallback(had_error);
+
+            modbus.emit("close");
+            modbus.removeAllListeners();
+        });
+
+        this._client.on("error", function(had_error) {
+            modbus.openFlag = false;
+            modbusSerialDebug("TCP port: signal error: " + had_error);
+            handleCallback(had_error);
+        });
+
+        this._client.on("timeout", function() {
+            // modbus.openFlag is left in its current state as it reflects two types of timeouts,
+            // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
+            // (this allows to continue Modbus request re-tries without reconnecting TCP).
+            modbusSerialDebug("TCP port: TimedOut");
+            handleCallback(new Error("TCP Connection Timed Out"));
+        });
     }
-
-    if (typeof(options) === "undefined") options = {};
-
-    this.connectOptions = {
-        host: ip || options.ip,
-        port: options.port || MODBUS_PORT,
-        localAddress: options.localAddress,
-        family: options.family
-    };
-
-    if(options.socket) {
-        if(options.socket instanceof net.Socket) {
-            this._externalSocket = options.socket;
-            this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
-        } else {
-            throw new Error("invalid socket provided");
-        }
-    }
-
-    // handle callback - call a callback function only once, for the first event
-    // it will triger
-    var handleCallback = function(had_error) {
-        if (modbus.callback) {
-            modbus.callback(had_error);
-            modbus.callback = null;
-        }
-    };
-
-    // init a socket
-    this._client = this._externalSocket || new net.Socket();
-
-    if (options.timeout) this._client.setTimeout(options.timeout);
-    this._client.on("data", function(data) {
-        var buffer;
-        var crc;
-        var length;
-
-        // data recived
-        modbusSerialDebug({ action: "receive tcp port strings", data: data });
-
-        // check data length
-        while (data.length > MIN_MBAP_LENGTH) {
-            // parse tcp header length
-            length = data.readUInt16BE(4);
-
-            // cut 6 bytes of mbap and copy pdu
-            buffer = Buffer.alloc(length + CRC_LENGTH);
-            data.copy(buffer, 0, MIN_MBAP_LENGTH);
-
-            // add crc to message
-            crc = crc16(buffer.slice(0, -CRC_LENGTH));
-            buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
-
-            // update transaction id and emit data
-            modbus._transactionIdRead = data.readUInt16BE(0);
-            modbus.emit("data", buffer);
-
-            // debug
-            modbusSerialDebug({ action: "parsed tcp port", buffer: buffer, transactionId: modbus._transactionIdRead });
-
-            // reset data
-            data = data.slice(length + MIN_MBAP_LENGTH);
-        }
-    });
-
-    this._client.on("connect", function() {
-        modbus.openFlag = true;
-        modbusSerialDebug("TCP port: signal connect");
-        handleCallback();
-    });
-
-    this._client.on("close", function(had_error) {
-        modbus.openFlag = false;
-        modbusSerialDebug("TCP port: signal close: " + had_error);
-        handleCallback(had_error);
-
-        modbus.emit("close");
-        modbus.removeAllListeners();
-    });
-
-    this._client.on("error", function(had_error) {
-        modbus.openFlag = false;
-        modbusSerialDebug("TCP port: signal error: " + had_error);
-        handleCallback(had_error);
-    });
-
-    this._client.on("timeout", function() {
-        // modbus.openFlag is left in its current state as it reflects two types of timeouts,
-        // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
-        // (this allows to continue Modbus request re-tries without reconnecting TCP).
-        modbusSerialDebug("TCP port: TimedOut");
-        handleCallback(new Error("TCP Connection Timed Out"));
-    });
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this.openFlag;
+    get isOpen() {
+        return this.openFlag;
+    }
+
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    open(callback) {
+        if(this._externalSocket === null) {
+            this.callback = callback;
+            this._client.connect(this.connectOptions);
+        } else if(this.openFlag) {
+            modbusSerialDebug("TCP port: external socket is opened");
+            callback(); // go ahead to setup existing socket
+        } else {
+            callback(new Error("TCP port: external socket is not opened"));
         }
-    });
+    }
 
-    EventEmitter.call(this);
-};
-util.inherits(TcpPort, EventEmitter);
-
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-TcpPort.prototype.open = function(callback) {
-    if(this._externalSocket === null) {
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
         this.callback = callback;
-        this._client.connect(this.connectOptions);
-    } else if(this.openFlag) {
-        modbusSerialDebug("TCP port: external socket is opened");
-        callback(); // go ahead to setup existing socket
-    } else {
-        callback(new Error("TCP port: external socket is not opened"));
-    }
-};
+        // DON'T pass callback to `end()` here, it will be handled by client.on('close') handler
+        this._client.end();
 
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-TcpPort.prototype.close = function(callback) {
-    this.callback = callback;
-    // DON'T pass callback to `end()` here, it will be handled by client.on('close') handler
-    this._client.end();
-
-    this.removeAllListeners();
-};
-
-/**
- * Simulate successful destroy port.
- *
- * @param callback
- */
-TcpPort.prototype.destroy = function(callback) {
-    this.callback = callback;
-    if (!this._client.destroyed) {
-        this._client.destroy();
-    }
-};
-
-/**
- * Send data to a modbus-tcp slave.
- *
- * @param data
- */
-TcpPort.prototype.write = function(data) {
-    if(data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
-        return;
+        this.removeAllListeners();
     }
 
-    // remember current unit and command
-    this._id = data[0];
-    this._cmd = data[1];
+    /**
+     * Simulate successful destroy port.
+     *
+     * @param callback
+     */
+    destroy(callback) {
+        this.callback = callback;
+        if (!this._client.destroyed) {
+            this._client.destroy();
+        }
+    }
 
-    // remove crc and add mbap
-    var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
-    buffer.writeUInt16BE(this._transactionIdWrite, 0);
-    buffer.writeUInt16BE(0, 2);
-    buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
-    data.copy(buffer, MIN_MBAP_LENGTH);
+    /**
+     * Send data to a modbus-tcp slave.
+     *
+     * @param data
+     */
+    write(data) {
+        if(data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
+            return;
+        }
 
-    modbusSerialDebug({
-        action: "send tcp port",
-        data: data,
-        buffer: buffer,
-        unitid: this._id,
-        functionCode: this._cmd,
-        transactionsId: this._transactionIdWrite
-    });
+        // remember current unit and command
+        this._id = data[0];
+        this._cmd = data[1];
 
-    // send buffer to slave
-    this._client.write(buffer);
+        // remove crc and add mbap
+        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        buffer.writeUInt16BE(this._transactionIdWrite, 0);
+        buffer.writeUInt16BE(0, 2);
+        buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
+        data.copy(buffer, MIN_MBAP_LENGTH);
 
-    // set next transaction id
-    this._transactionIdWrite = (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
-};
+        modbusSerialDebug({
+            action: "send tcp port",
+            data: data,
+            buffer: buffer,
+            unitid: this._id,
+            functionCode: this._cmd,
+            transactionsId: this._transactionIdWrite
+        });
+
+        // send buffer to slave
+        this._client.write(buffer);
+
+        // set next transaction id
+        this._transactionIdWrite = (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
+    }
+}
 
 /**
  * TCP port for Modbus.

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -1,5 +1,4 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var net = require("net");
@@ -17,266 +16,264 @@ var CRC_LENGTH = 2;
 
 var MODBUS_PORT = 502;
 
-/**
- * Simulate a modbus-RTU port using TCP connection
- * @module TcpRTUBufferedPort
- *
- * @param {string} ip - ip address
- * @param {object} options - all options as JSON object
- *   options.port: Nonstandard Modbus port (default is 502).
- *   options.localAddress: Local IP address to bind to, default is any.
- *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
- * @constructor
- */
-var TcpRTUBufferedPort = function(ip, options) {
-    var modbus = this;
-    modbus.openFlag = false;
-    modbus.callback = null;
-    modbus._transactionIdWrite = 1;
-    this._externalSocket = null;
+class TcpRTUBufferedPort extends EventEmitter {
+    /**
+     * Simulate a modbus-RTU port using TCP connection
+     * @module TcpRTUBufferedPort
+     *
+     * @param {string} ip - ip address
+     * @param {object} options - all options as JSON object
+     *   options.port: Nonstandard Modbus port (default is 502).
+     *   options.localAddress: Local IP address to bind to, default is any.
+     *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
+     * @constructor
+     */
+    constructor(ip, options) {
+        super();
 
-    // options
-    if(typeof ip === "object") {
-        options = ip;
-    }
-    if (typeof options === "undefined") options = {};
-    modbus.connectOptions = {
-        host: ip || options.ip,
-        port: options.port || MODBUS_PORT,
-        localAddress: options.localAddress,
-        family: options.family || 0
-    };
+        var modbus = this;
+        modbus.openFlag = false;
+        modbus.callback = null;
+        modbus._transactionIdWrite = 1;
+        this._externalSocket = null;
 
-    if(options.socket) {
-        if(options.socket instanceof net.Socket) {
-            this._externalSocket = options.socket;
-            this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
-        } else {
-            throw new Error("invalid socket provided");
+        // options
+        if(typeof ip === "object") {
+            options = ip;
         }
-    }
+        if (typeof options === "undefined") options = {};
+        modbus.connectOptions = {
+            host: ip || options.ip,
+            port: options.port || MODBUS_PORT,
+            localAddress: options.localAddress,
+            family: options.family || 0
+        };
 
-    // internal buffer
-    modbus._buffer = Buffer.alloc(0);
-
-    // handle callback - call a callback function only once, for the first event
-    // it will triger
-    var handleCallback = function(had_error) {
-        if (modbus.callback) {
-            modbus.callback(had_error);
-            modbus.callback = null;
-        }
-    };
-
-    // create a socket
-    modbus._client = this._externalSocket || new net.Socket();
-    if (options.timeout) this._client.setTimeout(options.timeout);
-
-    // register the port data event
-    modbus._client.on("data", function onData(data) {
-        // add data to buffer
-        modbus._buffer = Buffer.concat([modbus._buffer, data]);
-
-        modbusSerialDebug({
-            action: "receive tcp rtu buffered port",
-            data: data,
-            buffer: modbus._buffer
-        });
-
-        // check if buffer include a complete modbus answer
-        var bufferLength = modbus._buffer.length;
-
-        // check data length
-        if (bufferLength < MIN_MBAP_LENGTH) return;
-
-        // check buffer size for MAX_BUFFER_SIZE
-        if (bufferLength > MAX_BUFFER_LENGTH) {
-            modbus._buffer = modbus._buffer.slice(-MAX_BUFFER_LENGTH);
-            bufferLength = MAX_BUFFER_LENGTH;
-        }
-
-        // check data length
-        if (bufferLength < MIN_MBAP_LENGTH + EXCEPTION_LENGTH) return;
-
-        // loop and check length-sized buffer chunks
-        var maxOffset = bufferLength - MIN_MBAP_LENGTH;
-        for (var i = 0; i <= maxOffset; i++) {
-            modbus._transactionIdRead = modbus._buffer.readUInt16BE(i);
-            var protocolID = modbus._buffer.readUInt16BE(i + 2);
-            var msgLength = modbus._buffer.readUInt16BE(i + 4);
-            var cmd = modbus._buffer[i + 7];
-
-            modbusSerialDebug({
-                protocolID: protocolID,
-                msgLength: msgLength,
-                bufferLength: bufferLength,
-                cmd: cmd
-            });
-
-            if (
-                protocolID === 0 &&
-                cmd !== 0 &&
-                msgLength >= EXCEPTION_LENGTH &&
-                i + MIN_MBAP_LENGTH + msgLength <= bufferLength
-            ) {
-                // add crc and emit
-                modbus._emitData(i + MIN_MBAP_LENGTH, msgLength);
-                return;
+        if(options.socket) {
+            if(options.socket instanceof net.Socket) {
+                this._externalSocket = options.socket;
+                this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
+            } else {
+                throw new Error("invalid socket provided");
             }
         }
-    });
 
-    this._client.on("connect", function() {
-        modbus.openFlag = true;
-        handleCallback();
-    });
+        // internal buffer
+        modbus._buffer = Buffer.alloc(0);
 
-    this._client.on("close", function(had_error) {
-        modbus.openFlag = false;
-        handleCallback(had_error);
-        modbus.emit("close");
-    });
+        // handle callback - call a callback function only once, for the first event
+        // it will triger
+        var handleCallback = function(had_error) {
+            if (modbus.callback) {
+                modbus.callback(had_error);
+                modbus.callback = null;
+            }
+        };
 
-    this._client.on("error", function(had_error) {
-        modbus.openFlag = false;
-        handleCallback(had_error);
-    });
+        // create a socket
+        modbus._client = this._externalSocket || new net.Socket();
+        if (options.timeout) this._client.setTimeout(options.timeout);
 
-    this._client.on("timeout", function() {
-        // modbus.openFlag is left in its current state as it reflects two types of timeouts,
-        // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
-        // (this allows to continue Modbus request re-tries without reconnecting TCP).
-        modbusSerialDebug("TcpRTUBufferedPort port: TimedOut");
-        handleCallback(new Error("TcpRTUBufferedPort Connection Timed Out"));
-    });
+        // register the port data event
+        modbus._client.on("data", function onData(data) {
+            // add data to buffer
+            modbus._buffer = Buffer.concat([modbus._buffer, data]);
+
+            modbusSerialDebug({
+                action: "receive tcp rtu buffered port",
+                data: data,
+                buffer: modbus._buffer
+            });
+
+            // check if buffer include a complete modbus answer
+            var bufferLength = modbus._buffer.length;
+
+            // check data length
+            if (bufferLength < MIN_MBAP_LENGTH) return;
+
+            // check buffer size for MAX_BUFFER_SIZE
+            if (bufferLength > MAX_BUFFER_LENGTH) {
+                modbus._buffer = modbus._buffer.slice(-MAX_BUFFER_LENGTH);
+                bufferLength = MAX_BUFFER_LENGTH;
+            }
+
+            // check data length
+            if (bufferLength < MIN_MBAP_LENGTH + EXCEPTION_LENGTH) return;
+
+            // loop and check length-sized buffer chunks
+            var maxOffset = bufferLength - MIN_MBAP_LENGTH;
+            for (var i = 0; i <= maxOffset; i++) {
+                modbus._transactionIdRead = modbus._buffer.readUInt16BE(i);
+                var protocolID = modbus._buffer.readUInt16BE(i + 2);
+                var msgLength = modbus._buffer.readUInt16BE(i + 4);
+                var cmd = modbus._buffer[i + 7];
+
+                modbusSerialDebug({
+                    protocolID: protocolID,
+                    msgLength: msgLength,
+                    bufferLength: bufferLength,
+                    cmd: cmd
+                });
+
+                if (
+                    protocolID === 0 &&
+                    cmd !== 0 &&
+                    msgLength >= EXCEPTION_LENGTH &&
+                    i + MIN_MBAP_LENGTH + msgLength <= bufferLength
+                ) {
+                    // add crc and emit
+                    modbus._emitData(i + MIN_MBAP_LENGTH, msgLength);
+                    return;
+                }
+            }
+        });
+
+        this._client.on("connect", function() {
+            modbus.openFlag = true;
+            handleCallback();
+        });
+
+        this._client.on("close", function(had_error) {
+            modbus.openFlag = false;
+            handleCallback(had_error);
+            modbus.emit("close");
+        });
+
+        this._client.on("error", function(had_error) {
+            modbus.openFlag = false;
+            handleCallback(had_error);
+        });
+
+        this._client.on("timeout", function() {
+            // modbus.openFlag is left in its current state as it reflects two types of timeouts,
+            // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
+            // (this allows to continue Modbus request re-tries without reconnecting TCP).
+            modbusSerialDebug("TcpRTUBufferedPort port: TimedOut");
+            handleCallback(new Error("TcpRTUBufferedPort Connection Timed Out"));
+        });
+    }
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this.openFlag;
+    get isOpen() {
+        return this.openFlag;
+    }
+
+    /**
+     * Emit the received response, cut the buffer and reset the internal vars.
+     *
+     * @param {number} start the start index of the response within the buffer
+     * @param {number} length the length of the response
+     * @private
+     */
+    _emitData(start, length) {
+        var modbus = this;
+        var data = modbus._buffer.slice(start, start + length);
+
+        // cut the buffer
+        modbus._buffer = modbus._buffer.slice(start + length);
+
+        if (data.length > 0) {
+            var buffer = Buffer.alloc(data.length + CRC_LENGTH);
+            data.copy(buffer, 0);
+
+            // add crc
+            var crc = crc16(buffer.slice(0, -CRC_LENGTH));
+            buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
+
+            modbus.emit("data", buffer);
+
+            // debug
+            modbusSerialDebug({
+                action: "parsed tcp buffered port",
+                buffer: buffer,
+                transactionId: modbus._transactionIdRead
+            });
+        } else {
+            modbusSerialDebug({ action: "emit data to short", data: data });
         }
-    });
-
-    EventEmitter.call(this);
-};
-util.inherits(TcpRTUBufferedPort, EventEmitter);
-
-/**
- * Emit the received response, cut the buffer and reset the internal vars.
- *
- * @param {number} start the start index of the response within the buffer
- * @param {number} length the length of the response
- * @private
- */
-TcpRTUBufferedPort.prototype._emitData = function(start, length) {
-    var modbus = this;
-    var data = modbus._buffer.slice(start, start + length);
-
-    // cut the buffer
-    modbus._buffer = modbus._buffer.slice(start + length);
-
-    if (data.length > 0) {
-        var buffer = Buffer.alloc(data.length + CRC_LENGTH);
-        data.copy(buffer, 0);
-
-        // add crc
-        var crc = crc16(buffer.slice(0, -CRC_LENGTH));
-        buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
-
-        modbus.emit("data", buffer);
-
-        // debug
-        modbusSerialDebug({
-            action: "parsed tcp buffered port",
-            buffer: buffer,
-            transactionId: modbus._transactionIdRead
-        });
-    } else {
-        modbusSerialDebug({ action: "emit data to short", data: data });
     }
-};
 
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-TcpRTUBufferedPort.prototype.open = function(callback) {
-    if(this._externalSocket === null) {
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    open(callback) {
+        if(this._externalSocket === null) {
+            this.callback = callback;
+            this._client.connect(this.connectOptions);
+        } else if(this.openFlag) {
+            modbusSerialDebug("TcpRTUBuffered port: external socket is opened");
+            callback(); // go ahead to setup existing socket
+        } else {
+            callback(new Error("TcpRTUBuffered port: external socket is not opened"));
+        }
+    }
+
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
         this.callback = callback;
-        this._client.connect(this.connectOptions);
-    } else if(this.openFlag) {
-        modbusSerialDebug("TcpRTUBuffered port: external socket is opened");
-        callback(); // go ahead to setup existing socket
-    } else {
-        callback(new Error("TcpRTUBuffered port: external socket is not opened"));
-    }
-};
+        this._client.end(callback);
 
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-TcpRTUBufferedPort.prototype.close = function(callback) {
-    this.callback = callback;
-    this._client.end(callback);
-
-    this.removeAllListeners();
-};
-
-/**
- * Simulate successful destroy port.
- *
- * @param callback
- */
-TcpRTUBufferedPort.prototype.destroy = function(callback) {
-    this.callback = callback;
-    if (!this._client.destroyed) {
-        this._client.destroy();
-    }
-};
-
-/**
- * Send data to a modbus slave via telnet server.
- *
- * @param {Buffer} data
- */
-TcpRTUBufferedPort.prototype.write = function(data) {
-    if (data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug(
-            "expected length of data is to small - minimum is " +
-                MIN_DATA_LENGTH
-        );
-        return;
+        this.removeAllListeners();
     }
 
-    // remove crc and add mbap
-    var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
-    buffer.writeUInt16BE(this._transactionIdWrite, 0);
-    buffer.writeUInt16BE(0, 2);
-    buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
-    data.copy(buffer, MIN_MBAP_LENGTH);
+    /**
+     * Simulate successful destroy port.
+     *
+     * @param callback
+     */
+    destroy(callback) {
+        this.callback = callback;
+        if (!this._client.destroyed) {
+            this._client.destroy();
+        }
+    }
 
-    modbusSerialDebug({
-        action: "send tcp rtu buffered port",
-        data: data,
-        buffer: buffer,
-        transactionsId: this._transactionIdWrite
-    });
+    /**
+     * Send data to a modbus slave via telnet server.
+     *
+     * @param {Buffer} data
+     */
+    write(data) {
+        if (data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug(
+                "expected length of data is to small - minimum is " +
+                    MIN_DATA_LENGTH
+            );
+            return;
+        }
 
-    // get next transaction id
-    this._transactionIdWrite =
-        (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
+        // remove crc and add mbap
+        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        buffer.writeUInt16BE(this._transactionIdWrite, 0);
+        buffer.writeUInt16BE(0, 2);
+        buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
+        data.copy(buffer, MIN_MBAP_LENGTH);
 
-    // send buffer to slave
-    this._client.write(buffer);
-};
+        modbusSerialDebug({
+            action: "send tcp rtu buffered port",
+            data: data,
+            buffer: buffer,
+            transactionsId: this._transactionIdWrite
+        });
+
+        // get next transaction id
+        this._transactionIdWrite =
+            (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
+
+        // send buffer to slave
+        this._client.write(buffer);
+    }
+}
 
 /**
  * TCP RTU bufferd port for Modbus.

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -1,5 +1,4 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var net = require("net");
@@ -11,275 +10,273 @@ var MIN_DATA_LENGTH = 6;
 
 var TELNET_PORT = 2217;
 
-/**
- * Simulate a modbus-RTU port using Telent connection.
- *
- * @param ip
- * @param options
- * @constructor
- */
-var TelnetPort = function(ip, options) {
-    var self = this;
-    this.ip = ip;
-    this.openFlag = false;
-    this.callback = null;
-    this._externalSocket = null;
+class TelnetPort extends EventEmitter {
+    /**
+     * Simulate a modbus-RTU port using Telent connection.
+     *
+     * @param ip
+     * @param options
+     * @constructor
+     */
+    constructor(ip, options) {
+        super();
 
-    // options
-    if(typeof ip === "object") {
-        options = ip;
-        this.ip = options.ip;
-    }
-    if (typeof options === "undefined") options = {};
-    this.port = options.port || TELNET_PORT; // telnet server port
+        var self = this;
+        this.ip = ip;
+        this.openFlag = false;
+        this.callback = null;
+        this._externalSocket = null;
 
-    // internal buffer
-    this._buffer = Buffer.alloc(0);
-    this._id = 0;
-    this._cmd = 0;
-    this._length = 0;
-
-    // handle callback - call a callback function only once, for the first event
-    // it will triger
-    var handleCallback = function(had_error) {
-        if (self.callback) {
-            self.callback(had_error);
-            self.callback = null;
+        // options
+        if(typeof ip === "object") {
+            options = ip;
+            this.ip = options.ip;
         }
-    };
+        if (typeof options === "undefined") options = {};
+        this.port = options.port || TELNET_PORT; // telnet server port
 
-    if(options.socket) {
-        if(options.socket instanceof net.Socket) {
-            this._externalSocket = options.socket;
-            this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
-        } else {
-            throw new Error("invalid socket provided");
+        // internal buffer
+        this._buffer = Buffer.alloc(0);
+        this._id = 0;
+        this._cmd = 0;
+        this._length = 0;
+
+        // handle callback - call a callback function only once, for the first event
+        // it will triger
+        var handleCallback = function(had_error) {
+            if (self.callback) {
+                self.callback(had_error);
+                self.callback = null;
+            }
+        };
+
+        if(options.socket) {
+            if(options.socket instanceof net.Socket) {
+                this._externalSocket = options.socket;
+                this.openFlag = this._externalSocket.readyState === "opening" || this._externalSocket.readyState === "open";
+            } else {
+                throw new Error("invalid socket provided");
+            }
         }
-    }
 
-    // create a socket
-    this._client = this._externalSocket || new net.Socket();
-    if (options.timeout) this._client.setTimeout(options.timeout);
+        // create a socket
+        this._client = this._externalSocket || new net.Socket();
+        if (options.timeout) this._client.setTimeout(options.timeout);
 
-    // register the port data event
-    this._client.on("data", function onData(data) {
-        // add data to buffer
-        self._buffer = Buffer.concat([self._buffer, data]);
+        // register the port data event
+        this._client.on("data", function onData(data) {
+            // add data to buffer
+            self._buffer = Buffer.concat([self._buffer, data]);
 
-        // check if buffer include a complete modbus answer
-        var expectedLength = self._length;
-        var bufferLength = self._buffer.length;
-        modbusSerialDebug(
-            "on data expected length:" +
-                expectedLength +
-                " buffer length:" +
-                bufferLength
-        );
+            // check if buffer include a complete modbus answer
+            var expectedLength = self._length;
+            var bufferLength = self._buffer.length;
+            modbusSerialDebug(
+                "on data expected length:" +
+                    expectedLength +
+                    " buffer length:" +
+                    bufferLength
+            );
 
-        modbusSerialDebug({
-            action: "receive tcp telnet port",
-            data: data,
-            buffer: self._buffer
-        });
-        modbusSerialDebug(
-            JSON.stringify({
-                action: "receive tcp telnet port strings",
+            modbusSerialDebug({
+                action: "receive tcp telnet port",
                 data: data,
                 buffer: self._buffer
-            })
-        );
+            });
+            modbusSerialDebug(
+                JSON.stringify({
+                    action: "receive tcp telnet port strings",
+                    data: data,
+                    buffer: self._buffer
+                })
+            );
 
-        // check data length
-        if (expectedLength < 6 || bufferLength < EXCEPTION_LENGTH) return;
+            // check data length
+            if (expectedLength < 6 || bufferLength < EXCEPTION_LENGTH) return;
 
-        // loop and check length-sized buffer chunks
-        var maxOffset = bufferLength - EXCEPTION_LENGTH;
-        for (var i = 0; i <= maxOffset; i++) {
-            var unitId = self._buffer[i];
-            var functionCode = self._buffer[i + 1];
+            // loop and check length-sized buffer chunks
+            var maxOffset = bufferLength - EXCEPTION_LENGTH;
+            for (var i = 0; i <= maxOffset; i++) {
+                var unitId = self._buffer[i];
+                var functionCode = self._buffer[i + 1];
 
-            if (unitId !== self._id) continue;
+                if (unitId !== self._id) continue;
 
-            if (
-                functionCode === self._cmd &&
-                i + expectedLength <= bufferLength
-            ) {
-                self._emitData(i, expectedLength);
-                return;
+                if (
+                    functionCode === self._cmd &&
+                    i + expectedLength <= bufferLength
+                ) {
+                    self._emitData(i, expectedLength);
+                    return;
+                }
+                if (
+                    functionCode === (0x80 | self._cmd) &&
+                    i + EXCEPTION_LENGTH <= bufferLength
+                ) {
+                    self._emitData(i, EXCEPTION_LENGTH);
+                    return;
+                }
+
+                // frame header matches, but still missing bytes pending
+                if (functionCode === (0x7f & self._cmd)) break;
             }
-            if (
-                functionCode === (0x80 | self._cmd) &&
-                i + EXCEPTION_LENGTH <= bufferLength
-            ) {
-                self._emitData(i, EXCEPTION_LENGTH);
-                return;
-            }
+        });
 
-            // frame header matches, but still missing bytes pending
-            if (functionCode === (0x7f & self._cmd)) break;
-        }
-    });
+        this._client.on("connect", function() {
+            self.openFlag = true;
+            handleCallback();
+        });
 
-    this._client.on("connect", function() {
-        self.openFlag = true;
-        handleCallback();
-    });
+        this._client.on("close", function(had_error) {
+            self.openFlag = false;
+            handleCallback(had_error);
+            self.emit("close");
+        });
 
-    this._client.on("close", function(had_error) {
-        self.openFlag = false;
-        handleCallback(had_error);
-        self.emit("close");
-    });
+        this._client.on("error", function(had_error) {
+            self.openFlag = false;
+            handleCallback(had_error);
+        });
 
-    this._client.on("error", function(had_error) {
-        self.openFlag = false;
-        handleCallback(had_error);
-    });
-
-    this._client.on("timeout", function() {
-        // modbus.openFlag is left in its current state as it reflects two types of timeouts,
-        // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
-        // (this allows to continue Modbus request re-tries without reconnecting TCP).
-        modbusSerialDebug("TelnetPort port: TimedOut");
-        handleCallback(new Error("TelnetPort Connection Timed Out."));
-    });
+        this._client.on("timeout", function() {
+            // modbus.openFlag is left in its current state as it reflects two types of timeouts,
+            // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
+            // (this allows to continue Modbus request re-tries without reconnecting TCP).
+            modbusSerialDebug("TelnetPort port: TimedOut");
+            handleCallback(new Error("TelnetPort Connection Timed Out."));
+        });
+    }
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this.openFlag;
+    get isOpen() {
+        return this.openFlag;
+    }
+
+    /**
+     * Emit the received response, cut the buffer and reset the internal vars.
+     *
+     * @param {number} start the start index of the response within the buffer
+     * @param {number} length the length of the response
+     * @private
+     */
+    _emitData(start, length) {
+        this.emit("data", this._buffer.slice(start, start + length));
+        this._buffer = this._buffer.slice(start + length);
+
+        // reset internal vars
+        this._id = 0;
+        this._cmd = 0;
+        this._length = 0;
+    }
+
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    open(callback) {
+        if(this._externalSocket === null) {
+            this.callback = callback;
+            this._client.connect(this.port, this.ip);
+        } else if(this.openFlag) {
+            modbusSerialDebug("telnet port: external socket is opened");
+            callback(); // go ahead to setup existing socket
+        } else {
+            callback(new Error("telnet port: external socket is not opened"));
         }
-    });
+    }
 
-    EventEmitter.call(this);
-};
-util.inherits(TelnetPort, EventEmitter);
-
-/**
- * Emit the received response, cut the buffer and reset the internal vars.
- *
- * @param {number} start the start index of the response within the buffer
- * @param {number} length the length of the response
- * @private
- */
-TelnetPort.prototype._emitData = function(start, length) {
-    this.emit("data", this._buffer.slice(start, start + length));
-    this._buffer = this._buffer.slice(start + length);
-
-    // reset internal vars
-    this._id = 0;
-    this._cmd = 0;
-    this._length = 0;
-};
-
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-TelnetPort.prototype.open = function(callback) {
-    if(this._externalSocket === null) {
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
         this.callback = callback;
-        this._client.connect(this.port, this.ip);
-    } else if(this.openFlag) {
-        modbusSerialDebug("telnet port: external socket is opened");
-        callback(); // go ahead to setup existing socket
-    } else {
-        callback(new Error("telnet port: external socket is not opened"));
-    }
-};
-
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-TelnetPort.prototype.close = function(callback) {
-    this.callback = callback;
-    this._client.end();
-    this.removeAllListeners();
-};
-
-/**
- * Simulate successful destroy port.
- *
- * @param callback
- */
-TelnetPort.prototype.destroy = function(callback) {
-    this.callback = callback;
-    if (!this._client.destroyed) {
-        this._client.destroy();
-    }
-};
-
-/**
- * Send data to a modbus slave via telnet server.
- *
- * @param {Buffer} data
- */
-TelnetPort.prototype.write = function(data) {
-    if (data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug(
-            "expected length of data is to small - minimum is " +
-                MIN_DATA_LENGTH
-        );
-        return;
+        this._client.end();
+        this.removeAllListeners();
     }
 
-    var length = null;
-
-    // remember current unit and command
-    this._id = data[0];
-    this._cmd = data[1];
-
-    // calculate expected answer length
-    switch (this._cmd) {
-        case 1:
-        case 2:
-            length = data.readUInt16BE(4);
-            this._length = 3 + parseInt((length - 1) / 8 + 1) + 2;
-            break;
-        case 3:
-        case 4:
-            length = data.readUInt16BE(4);
-            this._length = 3 + 2 * length + 2;
-            break;
-        case 5:
-        case 6:
-        case 15:
-        case 16:
-            this._length = 6 + 2;
-            break;
-        default:
-            // raise and error ?
-            this._length = 0;
-            break;
+    /**
+     * Simulate successful destroy port.
+     *
+     * @param callback
+     */
+    destroy(callback) {
+        this.callback = callback;
+        if (!this._client.destroyed) {
+            this._client.destroy();
+        }
     }
 
-    // send buffer to slave
-    this._client.write(data);
+    /**
+     * Send data to a modbus slave via telnet server.
+     *
+     * @param {Buffer} data
+     */
+    write(data) {
+        if (data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug(
+                "expected length of data is to small - minimum is " +
+                    MIN_DATA_LENGTH
+            );
+            return;
+        }
 
-    modbusSerialDebug({
-        action: "send tcp telnet port",
-        data: data,
-        unitid: this._id,
-        functionCode: this._cmd
-    });
+        var length = null;
 
-    modbusSerialDebug(
-        JSON.stringify({
-            action: "send tcp telnet port strings",
+        // remember current unit and command
+        this._id = data[0];
+        this._cmd = data[1];
+
+        // calculate expected answer length
+        switch (this._cmd) {
+            case 1:
+            case 2:
+                length = data.readUInt16BE(4);
+                this._length = 3 + parseInt((length - 1) / 8 + 1) + 2;
+                break;
+            case 3:
+            case 4:
+                length = data.readUInt16BE(4);
+                this._length = 3 + 2 * length + 2;
+                break;
+            case 5:
+            case 6:
+            case 15:
+            case 16:
+                this._length = 6 + 2;
+                break;
+            default:
+                // raise and error ?
+                this._length = 0;
+                break;
+        }
+
+        // send buffer to slave
+        this._client.write(data);
+
+        modbusSerialDebug({
+            action: "send tcp telnet port",
             data: data,
             unitid: this._id,
             functionCode: this._cmd
-        })
-    );
-};
+        });
+
+        modbusSerialDebug(
+            JSON.stringify({
+                action: "send tcp telnet port strings",
+                data: data,
+                unitid: this._id,
+                functionCode: this._cmd
+            })
+        );
+    }
+}
 
 /**
  * Telnet port for Modbus.

--- a/ports/testport.js
+++ b/ports/testport.js
@@ -1,5 +1,5 @@
+/* eslint-disable class-methods-use-this */
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var modbusSerialDebug = require("debug")("modbus-serial");
@@ -11,306 +11,304 @@ var crc16 = require("../utils/crc16");
 
 var MIN_DATA_LENGTH = 7;
 
-/**
- * Simulate a serial port with 4 modbus-rtu slaves connected.
- *
- * 1 - a modbus slave working correctly
- * 2 - a modbus slave that answer short replays
- * 3 - a modbus slave that answer with bad crc
- * 4 - a modbus slave that answer with bad unit number
- * 5 - a modbus slave that answer with an exception
- * 6 - a modbus slave that times out (does not answer)
- */
-var TestPort = function() {
-    // simulate 11 input registers
-    this._registers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+class TestPort extends EventEmitter {
+    /**
+     * Simulate a serial port with 4 modbus-rtu slaves connected.
+     *
+     * 1 - a modbus slave working correctly
+     * 2 - a modbus slave that answer short replays
+     * 3 - a modbus slave that answer with bad crc
+     * 4 - a modbus slave that answer with bad unit number
+     * 5 - a modbus slave that answer with an exception
+     * 6 - a modbus slave that times out (does not answer)
+     */
+    constructor() {
+        super();
 
-    // simulate 11 holding registers
-    this._holding_registers = [0, 0, 0, 0, 0, 0, 0, 0, 0xa12b, 0xffff, 0xb21a];
+        // simulate 11 input registers
+        this._registers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-    // simulate 16 coils / digital inputs
-    this._coils = 0x0000; // TODO 0xa12b, 1010 0001 0010 1011
+        // simulate 11 holding registers
+        this._holding_registers = [0, 0, 0, 0, 0, 0, 0, 0, 0xa12b, 0xffff, 0xb21a];
+
+        // simulate 16 coils / digital inputs
+        this._coils = 0x0000; // TODO 0xa12b, 1010 0001 0010 1011
+    }
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return true;
-        }
-    });
-
-    EventEmitter.call(this);
-};
-util.inherits(TestPort, EventEmitter);
-
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-TestPort.prototype.open = function(callback) {
-    if (callback)
-        callback(null);
-};
-
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-TestPort.prototype.close = function(callback) {
-    if (callback)
-        callback(null);
-};
-
-/**
- * Simulate successful/failure port requests and replays.
- *
- * @param {Buffer} data
- */
-TestPort.prototype.write = function(data) {
-    var buffer = null;
-    var length = null;
-    var address = null;
-    var value = null;
-    var state = null;
-    var i = null;
-
-    if(data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
-        return;
+    get isOpen() {
+        return true;
     }
 
-    var unitNumber = data[0];
-    var functionCode = data[1];
-    var crc = data[data.length - 2] + data[data.length - 1] * 0x100;
-    // if crc is bad, ignore message
-    if (crc !== crc16(data.slice(0, -2))) {
-        return;
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    open(callback) {
+        if (callback)
+            callback(null);
     }
 
-    // function code 1 and 2
-    if (functionCode === 1 || functionCode === 2) {
-        address = data.readUInt16BE(2);
-        length = data.readUInt16BE(4);
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
+        if (callback)
+            callback(null);
+    }
 
-        // if length is bad, ignore message
-        if (data.length !== 8) {
+    /**
+     * Simulate successful/failure port requests and replays.
+     *
+     * @param {Buffer} data
+     */
+    write(data) {
+        var buffer = null;
+        var length = null;
+        var address = null;
+        var value = null;
+        var state = null;
+        var i = null;
+
+        if(data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
             return;
         }
 
-        // build answer
-        buffer = Buffer.alloc(3 + parseInt((length - 1) / 8 + 1) + 2);
-        buffer.writeUInt8(parseInt((length - 1) / 8 + 1), 2);
-
-        // read coils
-        buffer.writeUInt16LE(this._coils >> address, 3);
-    }
-
-    // function code 3
-    if (functionCode === 3) {
-        address = data.readUInt16BE(2);
-        length = data.readUInt16BE(4);
-
-        // if length is bad, ignore message
-        if (data.length !== 8) {
+        var unitNumber = data[0];
+        var functionCode = data[1];
+        var crc = data[data.length - 2] + data[data.length - 1] * 0x100;
+        // if crc is bad, ignore message
+        if (crc !== crc16(data.slice(0, -2))) {
             return;
         }
 
-        // build answer
-        buffer = Buffer.alloc(3 + length * 2 + 2);
-        buffer.writeUInt8(length * 2, 2);
+        // function code 1 and 2
+        if (functionCode === 1 || functionCode === 2) {
+            address = data.readUInt16BE(2);
+            length = data.readUInt16BE(4);
 
-        // read registers
-        for (i = 0; i < length; i++) {
-            buffer.writeUInt16BE(this._holding_registers[address + i], 3 + i * 2);
-        }
-    }
+            // if length is bad, ignore message
+            if (data.length !== 8) {
+                return;
+            }
 
-    // function code 4
-    if (functionCode === 4) {
-        address = data.readUInt16BE(2);
-        length = data.readUInt16BE(4);
+            // build answer
+            buffer = Buffer.alloc(3 + parseInt((length - 1) / 8 + 1) + 2);
+            buffer.writeUInt8(parseInt((length - 1) / 8 + 1), 2);
 
-        // if length is bad, ignore message
-        if (data.length !== 8) {
-            return;
+            // read coils
+            buffer.writeUInt16LE(this._coils >> address, 3);
         }
 
-        // build answer
-        buffer = Buffer.alloc(3 + length * 2 + 2);
-        buffer.writeUInt8(length * 2, 2);
+        // function code 3
+        if (functionCode === 3) {
+            address = data.readUInt16BE(2);
+            length = data.readUInt16BE(4);
 
-        // read registers
-        for (i = 0; i < length; i++) {
-            buffer.writeUInt16BE(this._registers[address + i], 3 + i * 2);
-        }
-    }
+            // if length is bad, ignore message
+            if (data.length !== 8) {
+                return;
+            }
 
-    // function code 5
-    if (functionCode === 5) {
-        address = data.readUInt16BE(2);
-        state = data.readUInt16BE(4);
+            // build answer
+            buffer = Buffer.alloc(3 + length * 2 + 2);
+            buffer.writeUInt8(length * 2, 2);
 
-        // if length is bad, ignore message
-        if (data.length !== 8) {
-            return;
-        }
-
-        // build answer
-        buffer = Buffer.alloc(8);
-        buffer.writeUInt16BE(address, 2);
-        buffer.writeUInt16BE(state, 4);
-
-        // write coil
-        if (state === 0xff00) {
-            this._coils |= (1 << address);
-        } else {
-            this._coils &= ~(1 << address);
-        }
-    }
-
-    // function code 6
-    if (functionCode === 6) {
-        address = data.readUInt16BE(2);
-        value = data.readUInt16BE(4);
-        // if length is bad, ignore message
-        if (data.length !== (6 + 2)) {
-            return;
-        }
-
-        // build answer
-        buffer = Buffer.alloc(8);
-        buffer.writeUInt16BE(address, 2);
-        buffer.writeUInt16BE(value, 4);
-
-        this._holding_registers[address] = value;
-    }
-
-    // function code 15
-    if (functionCode === 15) {
-        address = data.readUInt16BE(2);
-        length = data.readUInt16BE(4);
-
-        // if length is bad, ignore message
-        if (data.length !== 7 + Math.ceil(length / 8) + 2) {
-            return;
-        }
-
-        // build answer
-        buffer = Buffer.alloc(8);
-        buffer.writeUInt16BE(address, 2);
-        buffer.writeUInt16BE(length, 4);
-
-        // write coils
-        for (i = 0; i < length; i++) {
-            state = data.readBit(i, 7);
-
-            if (state) {
-                this._coils |= (1 << (address + i));
-            } else {
-                this._coils &= ~(1 << (address + i));
+            // read registers
+            for (i = 0; i < length; i++) {
+                buffer.writeUInt16BE(this._holding_registers[address + i], 3 + i * 2);
             }
         }
-    }
 
-    // function code 16
-    if (functionCode === 16) {
-        address = data.readUInt16BE(2);
-        length = data.readUInt16BE(4);
+        // function code 4
+        if (functionCode === 4) {
+            address = data.readUInt16BE(2);
+            length = data.readUInt16BE(4);
 
-        // if length is bad, ignore message
-        if (data.length !== (7 + length * 2 + 2)) {
-            return;
-        }
-
-        // build answer
-        buffer = Buffer.alloc(8);
-        buffer.writeUInt16BE(address, 2);
-        buffer.writeUInt16BE(length, 4);
-
-        // write registers
-        for (i = 0; i < length; i++) {
-            this._holding_registers[address + i] = data.readUInt16BE(7 + i * 2);
-        }
-    }
-
-    if (functionCode === 43) {
-        const productCode = "MyProductCode1234";
-        buffer = Buffer.alloc(12 + productCode.length);
-        buffer.writeUInt8(16, 2); // MEI Type
-        buffer.writeUInt8(data.readInt8(3), 3); // read device ID code
-        buffer.writeUInt8(0x01, 4); // conformity level
-        buffer.writeUInt8(0, 5); // number of follows left
-        buffer.writeUInt8(0, 6); // next object ID
-        buffer.writeUInt8(1, 7); // number of objects
-        buffer.writeUInt8(data.readInt8(4), 8);
-        buffer.writeUInt8(productCode.length, 9);
-        buffer.write(productCode, 10, productCode.length, "ascii");
-    }
-
-    // send data back
-    if (buffer) {
-        // add unit number and function code
-        buffer.writeUInt8(unitNumber, 0);
-        buffer.writeUInt8(functionCode, 1);
-
-        // corrupt the answer
-        switch (unitNumber) {
-            case 1:
-                // unit 1: answers correctly
-                break;
-            case 2:
-                // unit 2: answers short data
-                buffer = buffer.slice(0, buffer.length - 5);
-                break;
-            case 4:
-                // unit 4: answers with bad unit number
-                buffer[0] = unitNumber + 2;
-                break;
-            case 5:
-                // unit 5: answers with exception
-                buffer.writeUInt8(functionCode + 128, 1);
-                buffer.writeUInt8(4, 2);
-                buffer = buffer.slice(0, 5);
-                break;
-            case 6:
-                // unit 6: does not answer
+            // if length is bad, ignore message
+            if (data.length !== 8) {
                 return;
+            }
+
+            // build answer
+            buffer = Buffer.alloc(3 + length * 2 + 2);
+            buffer.writeUInt8(length * 2, 2);
+
+            // read registers
+            for (i = 0; i < length; i++) {
+                buffer.writeUInt16BE(this._registers[address + i], 3 + i * 2);
+            }
         }
 
-        // add crc
-        crc = crc16(buffer.slice(0, -2));
-        buffer.writeUInt16LE(crc, buffer.length - 2);
+        // function code 5
+        if (functionCode === 5) {
+            address = data.readUInt16BE(2);
+            state = data.readUInt16BE(4);
 
-        // unit 3: answers with bad crc
-        if (unitNumber === 3) {
-            buffer.writeUInt16LE(crc + 1, buffer.length - 2);
+            // if length is bad, ignore message
+            if (data.length !== 8) {
+                return;
+            }
+
+            // build answer
+            buffer = Buffer.alloc(8);
+            buffer.writeUInt16BE(address, 2);
+            buffer.writeUInt16BE(state, 4);
+
+            // write coil
+            if (state === 0xff00) {
+                this._coils |= (1 << address);
+            } else {
+                this._coils &= ~(1 << address);
+            }
         }
 
-        this.emit("data", buffer);
+        // function code 6
+        if (functionCode === 6) {
+            address = data.readUInt16BE(2);
+            value = data.readUInt16BE(4);
+            // if length is bad, ignore message
+            if (data.length !== (6 + 2)) {
+                return;
+            }
 
-        modbusSerialDebug({
-            action: "send test port",
-            data: data,
-            buffer: buffer,
-            unitid: unitNumber,
-            functionCode: functionCode
-        });
+            // build answer
+            buffer = Buffer.alloc(8);
+            buffer.writeUInt16BE(address, 2);
+            buffer.writeUInt16BE(value, 4);
 
-        modbusSerialDebug(JSON.stringify({
-            action: "send test port strings",
-            data: data,
-            buffer: buffer,
-            unitid: unitNumber,
-            functionCode: functionCode
-        }));
+            this._holding_registers[address] = value;
+        }
+
+        // function code 15
+        if (functionCode === 15) {
+            address = data.readUInt16BE(2);
+            length = data.readUInt16BE(4);
+
+            // if length is bad, ignore message
+            if (data.length !== 7 + Math.ceil(length / 8) + 2) {
+                return;
+            }
+
+            // build answer
+            buffer = Buffer.alloc(8);
+            buffer.writeUInt16BE(address, 2);
+            buffer.writeUInt16BE(length, 4);
+
+            // write coils
+            for (i = 0; i < length; i++) {
+                state = data.readBit(i, 7);
+
+                if (state) {
+                    this._coils |= (1 << (address + i));
+                } else {
+                    this._coils &= ~(1 << (address + i));
+                }
+            }
+        }
+
+        // function code 16
+        if (functionCode === 16) {
+            address = data.readUInt16BE(2);
+            length = data.readUInt16BE(4);
+
+            // if length is bad, ignore message
+            if (data.length !== (7 + length * 2 + 2)) {
+                return;
+            }
+
+            // build answer
+            buffer = Buffer.alloc(8);
+            buffer.writeUInt16BE(address, 2);
+            buffer.writeUInt16BE(length, 4);
+
+            // write registers
+            for (i = 0; i < length; i++) {
+                this._holding_registers[address + i] = data.readUInt16BE(7 + i * 2);
+            }
+        }
+
+        if (functionCode === 43) {
+            const productCode = "MyProductCode1234";
+            buffer = Buffer.alloc(12 + productCode.length);
+            buffer.writeUInt8(16, 2); // MEI Type
+            buffer.writeUInt8(data.readInt8(3), 3); // read device ID code
+            buffer.writeUInt8(0x01, 4); // conformity level
+            buffer.writeUInt8(0, 5); // number of follows left
+            buffer.writeUInt8(0, 6); // next object ID
+            buffer.writeUInt8(1, 7); // number of objects
+            buffer.writeUInt8(data.readInt8(4), 8);
+            buffer.writeUInt8(productCode.length, 9);
+            buffer.write(productCode, 10, productCode.length, "ascii");
+        }
+
+        // send data back
+        if (buffer) {
+            // add unit number and function code
+            buffer.writeUInt8(unitNumber, 0);
+            buffer.writeUInt8(functionCode, 1);
+
+            // corrupt the answer
+            switch (unitNumber) {
+                case 1:
+                    // unit 1: answers correctly
+                    break;
+                case 2:
+                    // unit 2: answers short data
+                    buffer = buffer.slice(0, buffer.length - 5);
+                    break;
+                case 4:
+                    // unit 4: answers with bad unit number
+                    buffer[0] = unitNumber + 2;
+                    break;
+                case 5:
+                    // unit 5: answers with exception
+                    buffer.writeUInt8(functionCode + 128, 1);
+                    buffer.writeUInt8(4, 2);
+                    buffer = buffer.slice(0, 5);
+                    break;
+                case 6:
+                    // unit 6: does not answer
+                    return;
+            }
+
+            // add crc
+            crc = crc16(buffer.slice(0, -2));
+            buffer.writeUInt16LE(crc, buffer.length - 2);
+
+            // unit 3: answers with bad crc
+            if (unitNumber === 3) {
+                buffer.writeUInt16LE(crc + 1, buffer.length - 2);
+            }
+
+            this.emit("data", buffer);
+
+            modbusSerialDebug({
+                action: "send test port",
+                data: data,
+                buffer: buffer,
+                unitid: unitNumber,
+                functionCode: functionCode
+            });
+
+            modbusSerialDebug(JSON.stringify({
+                action: "send test port strings",
+                data: data,
+                buffer: buffer,
+                unitid: unitNumber,
+                functionCode: functionCode
+            }));
+        }
     }
-};
+}
 
 /**
  * Test port for Modbus.

--- a/ports/udpport.js
+++ b/ports/udpport.js
@@ -1,5 +1,4 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 var dgram = require("dgram");
@@ -14,153 +13,152 @@ var MIN_DATA_LENGTH = 6;
 var MIN_MBAP_LENGTH = 6;
 var CRC_LENGTH = 2;
 
-/**
- * Simulate a modbus-RTU port using modbus-udp.
- *
- * @param ip
- * @param options
- * @constructor
- */
-var ModbusUdpPort = function(ip, options) {
-    var modbus = this;
-    this.ip = ip;
-    this.openFlag = false;
-    this._transactionIdWrite = 1;
-    this.port = options.port || MODBUS_PORT;
+class ModbusUdpPort extends EventEmitter {
+    /**
+     * Simulate a modbus-RTU port using modbus-udp.
+     *
+     * @param ip
+     * @param options
+     * @constructor
+     */
+    constructor(ip, options) {
+        super();
 
-    // options
-    if (typeof(options) === "undefined") options = {};
+        var modbus = this;
+        this.ip = ip;
+        this.openFlag = false;
+        this._transactionIdWrite = 1;
+        this.port = options.port || MODBUS_PORT;
 
-    // create a socket
-    this._client = dgram.createSocket("udp4");
+        // options
+        if (typeof(options) === "undefined") options = {};
 
-    // Bind to the same port as we're sending to
-    this._client.bind();
+        // create a socket
+        this._client = dgram.createSocket("udp4");
 
-    // wait for answer
-    const self = this;
-    this._client.on("message", function(data, rinfo) {
-        var buffer;
-        var crc;
-        var length;
+        // Bind to the same port as we're sending to
+        this._client.bind();
 
-        // Filter stuff not intended for us
-        if(rinfo.address !== self.ip || rinfo.port !== self.port)
-        {
-            return;
-        }
+        // wait for answer
+        const self = this;
+        this._client.on("message", function(data, rinfo) {
+            var buffer;
+            var crc;
+            var length;
 
-        // data received
-        modbusSerialDebug({ action: "receive udp port strings", data: data });
+            // Filter stuff not intended for us
+            if(rinfo.address !== self.ip || rinfo.port !== self.port)
+            {
+                return;
+            }
 
-        // check data length
-        while (data.length > MIN_MBAP_LENGTH) {
-            // parse udp header length
-            length = data.readUInt16BE(4);
+            // data received
+            modbusSerialDebug({ action: "receive udp port strings", data: data });
 
-            // cut 6 bytes of mbap and copy pdu
-            buffer = Buffer.alloc(length + CRC_LENGTH);
-            data.copy(buffer, 0, MIN_MBAP_LENGTH);
+            // check data length
+            while (data.length > MIN_MBAP_LENGTH) {
+                // parse udp header length
+                length = data.readUInt16BE(4);
 
-            // add crc to message
-            crc = crc16(buffer.slice(0, -CRC_LENGTH));
-            buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
+                // cut 6 bytes of mbap and copy pdu
+                buffer = Buffer.alloc(length + CRC_LENGTH);
+                data.copy(buffer, 0, MIN_MBAP_LENGTH);
 
-            // update transaction id and emit data
-            modbus._transactionIdRead = data.readUInt16BE(0);
-            modbus.emit("data", buffer);
+                // add crc to message
+                crc = crc16(buffer.slice(0, -CRC_LENGTH));
+                buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
 
-            // debug
-            modbusSerialDebug({ action: "parsed udp port", buffer: buffer, transactionId: modbus._transactionIdRead });
+                // update transaction id and emit data
+                modbus._transactionIdRead = data.readUInt16BE(0);
+                modbus.emit("data", buffer);
 
-            // reset data
-            data = data.slice(length + MIN_MBAP_LENGTH);
-        }
-    });
+                // debug
+                modbusSerialDebug({ action: "parsed udp port", buffer: buffer, transactionId: modbus._transactionIdRead });
 
-    this._client.on("listening", function() {
-        modbus.openFlag = true;
-    });
+                // reset data
+                data = data.slice(length + MIN_MBAP_LENGTH);
+            }
+        });
 
-    this._client.on("close", function() {
-        modbus.openFlag = false;
-    });
+        this._client.on("listening", function() {
+            modbus.openFlag = true;
+        });
+
+        this._client.on("close", function() {
+            modbus.openFlag = false;
+        });
+    }
 
     /**
      * Check if port is open.
      *
      * @returns {boolean}
      */
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this.openFlag;
-        }
-    });
-
-    EventEmitter.call(this);
-};
-util.inherits(ModbusUdpPort, EventEmitter);
-
-/**
- * Simulate successful port open.
- *
- * @param callback
- */
-ModbusUdpPort.prototype.open = function(callback) {
-    if (callback)
-        callback(null);
-};
-
-/**
- * Simulate successful close port.
- *
- * @param callback
- */
-ModbusUdpPort.prototype.close = function(callback) {
-    this._client.close();
-    if (callback)
-        callback(null);
-};
-
-/**
- * Send data to a modbus-udp slave.
- *
- * @param data
- */
-ModbusUdpPort.prototype.write = function(data) {
-    if(data.length < MIN_DATA_LENGTH) {
-        modbusSerialDebug("expected length of data is too small - minimum is " + MIN_DATA_LENGTH);
-        return;
+    get isOpen() {
+        return this.openFlag;
     }
 
-    // remember current unit and command
-    this._id = data[0];
-    this._cmd = data[1];
+    /**
+     * Simulate successful port open.
+     *
+     * @param callback
+     */
+    // eslint-disable-next-line class-methods-use-this
+    open(callback) {
+        if (callback)
+            callback(null);
+    }
 
-    // remove crc and add mbap
-    var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
-    buffer.writeUInt16BE(this._transactionIdWrite, 0);
-    buffer.writeUInt16BE(0, 2);
-    buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
-    data.copy(buffer, MIN_MBAP_LENGTH);
+    /**
+     * Simulate successful close port.
+     *
+     * @param callback
+     */
+    close(callback) {
+        this._client.close();
+        if (callback)
+            callback(null);
+    }
+
+    /**
+     * Send data to a modbus-udp slave.
+     *
+     * @param data
+     */
+    write(data) {
+        if(data.length < MIN_DATA_LENGTH) {
+            modbusSerialDebug("expected length of data is too small - minimum is " + MIN_DATA_LENGTH);
+            return;
+        }
+
+        // remember current unit and command
+        this._id = data[0];
+        this._cmd = data[1];
+
+        // remove crc and add mbap
+        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        buffer.writeUInt16BE(this._transactionIdWrite, 0);
+        buffer.writeUInt16BE(0, 2);
+        buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);
+        data.copy(buffer, MIN_MBAP_LENGTH);
 
 
-    modbusSerialDebug({
-        action: "send modbus udp port",
-        data: data,
-        buffer: buffer,
-        unitid: this._id,
-        functionCode: this._cmd
-    });
+        modbusSerialDebug({
+            action: "send modbus udp port",
+            data: data,
+            buffer: buffer,
+            unitid: this._id,
+            functionCode: this._cmd
+        });
 
-    // send buffer via udp
-    this._client.send(buffer, 0, buffer.length, this.port, this.ip);
+        // send buffer via udp
+        this._client.send(buffer, 0, buffer.length, this.port, this.ip);
 
-    // set next transaction id
-    this._transactionIdWrite = (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
+        // set next transaction id
+        this._transactionIdWrite = (this._transactionIdWrite + 1) % MAX_TRANSACTIONS;
 
-};
+    }
+}
 
 /**
  * UDP port for Modbus.

--- a/test/mocks/SerialPortMock.js
+++ b/test/mocks/SerialPortMock.js
@@ -1,53 +1,50 @@
 "use strict";
-var util = require("util");
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
 
+class SerialPortMock extends EventEmitter {
+    /**
+     * Mock for SerialPort
+     */
+    constructor(options, callback) {
+        super();
 
-/**
- * Mock for SerialPort
- */
-var SerialPortMock = function(options, callback) {
-    EventEmitter.call(this);
-    this._openFlag = false;
-    if (callback) {
-        callback(null);
-    }
-
-    Object.defineProperty(this, "isOpen", {
-        enumerable: true,
-        get: function() {
-            return this._openFlag;
+        this._openFlag = false;
+        if (callback) {
+            callback(null);
         }
-    });
-};
-util.inherits(SerialPortMock, EventEmitter);
-
-SerialPortMock.prototype.open = function(callback) {
-    this._openFlag = true;
-    if (callback) {
-        callback(null);
     }
-    this.emit("open");
-};
 
-SerialPortMock.prototype.write = function(buffer, callback) {
-    this._data = buffer;
-    if (callback) {
-        callback(null);
+    get isOpen() {
+        return this._openFlag;
     }
-};
 
-SerialPortMock.prototype.close = function(callback) {
-    this._openFlag = false;
-    if (callback) {
-        callback(null);
+    open(callback) {
+        this._openFlag = true;
+        if (callback) {
+            callback(null);
+        }
+        this.emit("open");
     }
-    this.emit("close");
-};
 
-SerialPortMock.prototype.receive = function(buffer) {
-    this.emit("data", buffer);
-};
+    write(buffer, callback) {
+        this._data = buffer;
+        if (callback) {
+            callback(null);
+        }
+    }
+
+    close(callback) {
+        this._openFlag = false;
+        if (callback) {
+            callback(null);
+        }
+        this.emit("close");
+    }
+
+    receive(buffer) {
+        this.emit("data", buffer);
+    }
+}
 
 module.exports = { SerialPort: SerialPortMock };

--- a/test/mocks/dgramMock.js
+++ b/test/mocks/dgramMock.js
@@ -1,53 +1,48 @@
 "use strict";
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
-var util = require("util");
 
-var Socket = function() {
-    EventEmitter.call(this);
-};
-
-Socket.prototype.connect = function(port, host, connectListener) {
-    this.emit("connect");
-    if (connectListener) {
-        connectListener(null);
+class Socket extends EventEmitter {
+    connect(port, host, connectListener) {
+        this.emit("connect");
+        if (connectListener) {
+            connectListener(null);
+        }
     }
-};
-util.inherits(Socket, EventEmitter);
 
-Socket.prototype.close = function(callback) {
-    this.emit("close", false);
-    if (callback) {
-        callback();
+    close(callback) {
+        this.emit("close", false);
+        if (callback) {
+            callback();
+        }
     }
-};
 
-Socket.prototype.send = function(buffer, offset, length, port, address, callback) {
-    this._data = buffer;
-    this._offset = offset;
-    this._length = length;
-    this._port = port;
-    this._address = address;
-    if (callback) {
-        callback(null);
+    send(buffer, offset, length, port, address, callback) {
+        this._data = buffer;
+        this._offset = offset;
+        this._length = length;
+        this._port = port;
+        this._address = address;
+        if (callback) {
+            callback(null);
+        }
     }
-};
 
-Socket.prototype.bind = function() {
-    this.emit("listening");
-};
+    bind() {
+        this.emit("listening");
+    }
 
-// Obsolete? It doesn't reflect the dgram interface
-Socket.prototype.listen = function() {
-    this.emit("listening");
-};
+    // Obsolete? It doesn't reflect the dgram interface
+    listen() {
+        this.emit("listening");
+    }
 
-Socket.prototype.receive = function(buffer) {
-    this.emit("message", buffer, { address: this._address, port: this._port, size: this._data.length });
-};
+    receive(buffer) {
+        this.emit("message", buffer, { address: this._address, port: this._port, size: this._data.length });
+    }
+}
 
 exports.Socket = Socket;
-
 
 exports.createSocket = function(type, listener) {
     return new Socket(type, listener);

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -1,62 +1,57 @@
 "use strict";
 var events = require("events");
 var EventEmitter = events.EventEmitter || events;
-var util = require("util");
 
-var Socket = function() {
-    EventEmitter.call(this);
-    this.destroyed = false;
-};
-util.inherits(Socket, EventEmitter);
-
-Socket.prototype.connect = function(port, host, connectListener) {
-    this.emit("connect");
-    if (connectListener) {
-        connectListener(null);
+class Socket extends EventEmitter {
+    constructor() {
+        super();
+        this.destroyed = false;
     }
-};
 
-Socket.prototype.end = function() {
-    this.emit("close", false);
-};
+    connect(port, host, connectListener) {
+        this.emit("connect");
+        if (connectListener) {
+            connectListener(null);
+        }
+    }
 
-Socket.prototype.write = function(data) {
-    this._data = data;
-};
+    end() {
+        this.emit("close", false);
+    }
 
-Socket.prototype.receive = function(buffer) {
-    this.emit("data", buffer);
-};
+    write(data) {
+        this._data = data;
+    }
 
-Socket.prototype.destroy = function() {
-    this.emit("close", true);
-    this.destroyed = true;
-};
+    receive(buffer) {
+        this.emit("data", buffer);
+    }
+
+    destroy() {
+        this.emit("close", true);
+        this.destroyed = true;
+    }
+}
 
 exports.Socket = Socket;
 
+class Server extends EventEmitter {
+    connect(socket) {
+        this.emit("connection", socket);
+    }
 
+    listen() {
+        this.emit("listening");
+    }
 
-var Server = function() {
-    EventEmitter.call(this);
-};
-util.inherits(Server, EventEmitter);
+    end() {
+        this.emit("close", false);
+    }
 
-Server.prototype.connect = function(socket) {
-    this.emit("connection", socket);
-};
-
-Server.prototype.listen = function() {
-    this.emit("listening");
-};
-
-Server.prototype.end = function() {
-    this.emit("close", false);
-};
-
-Server.prototype.receive = function(buffer) {
-    this.emit("data", buffer);
-};
+    receive(buffer) {
+        this.emit("data", buffer);
+    }
+}
 
 exports.Server = Server;
 


### PR DESCRIPTION
All [currently maintained Node.js versions](https://nodejs.org/en/about/releases/) support the native class syntax these days. This PR converts all of the `prototype` based classes to native classes to make the code a little easier on the eyes. :)

Review with "Hide whitespace" is recommended: https://github.com/yaacov/node-modbus-serial/pull/451/files?w=1 😅 