### PR TITLE
Use let/const instead of var

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -200,7 +200,7 @@
         "no-useless-escape": "error",
         "no-useless-rename": "error",
         "no-useless-return": "off",
-        "no-var": "off",
+        "no-var": "error",
         "no-void": "error",
         "no-warning-comments": "off",
         "no-whitespace-before-property": "error",

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ This module has not been tested on every single version of NodeJS. For best resu
 ###### Read and Write
 ``` javascript
 // create an empty modbus client
-var ModbusRTU = require("modbus-serial");
-var client = new ModbusRTU();
+const ModbusRTU = require("modbus-serial");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 client.connectRTUBuffered("/dev/ttyUSB0", { baudRate: 9600 }, write);
@@ -173,8 +173,8 @@ getMetersValue(metersIdList);
 ###### Logger Serial
 ``` javascript
 // create an empty modbus client
-var ModbusRTU = require("modbus-serial");
-var client = new ModbusRTU();
+const ModbusRTU = require("modbus-serial");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 client.connectRTUBuffered("/dev/ttyUSB0", { baudRate: 9600 });
@@ -192,8 +192,8 @@ setInterval(function() {
 ###### Logger TCP
 ``` javascript
 // create an empty modbus client
-var ModbusRTU = require("modbus-serial");
-var client = new ModbusRTU();
+const ModbusRTU = require("modbus-serial");
+const client = new ModbusRTU();
 
 // open connection to a tcp line
 client.connectTCP("127.0.0.1", { port: 8502 });
@@ -211,8 +211,8 @@ setInterval(function() {
 ###### Logger UDP
 ``` javascript
 // create an empty modbus client
-var ModbusRTU = require("modbus-serial");
-var client = new ModbusRTU();
+const ModbusRTU = require("modbus-serial");
+const client = new ModbusRTU();
 
 // open connection to a udp line
 client.connectUDP("127.0.0.1", { port: 8502 });
@@ -230,8 +230,8 @@ setInterval(function() {
 ###### ModbusTCP Server
 ``` javascript
 // create an empty modbus client
-var ModbusRTU = require("modbus-serial");
-var vector = {
+const ModbusRTU = require("modbus-serial");
+const vector = {
     getInputRegister: function(addr, unitID) {
         // Synchronous handling
         return addr;
@@ -275,7 +275,7 @@ var vector = {
 
 // set the server to answer for modbus requests
 console.log("ModbusTCP listening on modbus://0.0.0.0:8502");
-var serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
+const serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
 
 serverTCP.on("socketError", function(err){
     // Handle socket error if needed, can be ignored
@@ -286,8 +286,8 @@ serverTCP.on("socketError", function(err){
 ###### Read and Write Modbus ASCII
 ``` javascript
 // create an empty modbus client
-var Modbus = require("modbus-serial");
-var client = new Modbus();
+const Modbus = require("modbus-serial");
+const client = new Modbus();
 
 // open connection to a serial port
 client.connectAsciiSerial(

--- a/apis/connection.js
+++ b/apis/connection.js
@@ -15,17 +15,17 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF  THIS SOFTWARE.
  */
 
-var MIN_MODBUSRTU_FRAMESZ = 5;
+const MIN_MODBUSRTU_FRAMESZ = 5;
 
 /**
  * Adds connection shorthand API to a Modbus objext
  *
  * @param {ModbusRTU} Modbus the ModbusRTU object.
  */
-var addConnctionAPI = function(Modbus) {
-    var cl = Modbus.prototype;
+const addConnctionAPI = function(Modbus) {
+    const cl = Modbus.prototype;
 
-    var open = function(obj, next) {
+    const open = function(obj, next) {
         /* the function check for a callback
          * if we have a callback, use it
          * o/w build a promise.
@@ -74,7 +74,7 @@ var addConnctionAPI = function(Modbus) {
         options.platformOptions = { vmin: MIN_MODBUSRTU_FRAMESZ, vtime: 0 };
 
         // create the SerialPort
-        var SerialPort = require("serialport").SerialPort;
+        const SerialPort = require("serialport").SerialPort;
         this._port = new SerialPort(Object.assign({}, { path }, options));
 
         // open and call next
@@ -101,7 +101,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the TcpPort
-        var TcpPort = require("../ports/tcpport");
+        const TcpPort = require("../ports/tcpport");
         if (this._timeout) {
             options.timeout = this._timeout;
         }
@@ -162,7 +162,7 @@ var addConnctionAPI = function(Modbus) {
             options = {};
         }
 
-        var TcpRTUBufferedPort = require("../ports/tcprtubufferedport");
+        const TcpRTUBufferedPort = require("../ports/tcprtubufferedport");
         if (this._timeout) {
             options.timeout = this._timeout;
         }
@@ -216,7 +216,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the TcpPort
-        var TelnetPort = require("../ports/telnetport");
+        const TelnetPort = require("../ports/telnetport");
         if (this._timeout) {
             options.timeout = this._timeout;
         }
@@ -270,7 +270,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the TcpPort
-        var C701Port = require("../ports/c701port");
+        const C701Port = require("../ports/c701port");
         this._port = new C701Port(ip, options);
 
         // open and call next
@@ -297,7 +297,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the UdpPort
-        var UdpPort = require("../ports/udpport");
+        const UdpPort = require("../ports/udpport");
         this._port = new UdpPort(ip, options);
 
         // open and call next
@@ -324,7 +324,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the SerialPort
-        var SerialPort = require("../ports/rtubufferedport");
+        const SerialPort = require("../ports/rtubufferedport");
         this._port = new SerialPort(path, options);
 
         // set vmin to smallest modbus packet size
@@ -354,7 +354,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the ASCII SerialPort
-        var SerialPortAscii = require("../ports/asciiport");
+        const SerialPortAscii = require("../ports/asciiport");
         this._port = new SerialPortAscii(path, options);
 
         // open and call next
@@ -399,7 +399,7 @@ var addConnctionAPI = function(Modbus) {
         }
 
         // create the TcpPort
-        var BlePort = require("../ports/bleport");
+        const BlePort = require("../ports/bleport");
         if (this._timeout) {
             options.timeout = this._timeout;
         }

--- a/apis/promise.js
+++ b/apis/promise.js
@@ -22,10 +22,10 @@
  * @return a function that calls function "f" and return a promise.
  * @private
  */
-var _convert = function(f) {
-    var converted = function(address, arg, next) {
-        var client = this;
-        var id = this._unitID;
+const _convert = function(f) {
+    const converted = function(address, arg, next) {
+        const client = this;
+        const id = this._unitID;
 
         /* the function check for a callback
          * if we have a callback, use it
@@ -36,7 +36,7 @@ var _convert = function(f) {
             f.bind(client)(id, address, arg, next);
         } else {
             // o/w use  a promise
-            var promise = new Promise(function(resolve, reject) {
+            const promise = new Promise(function(resolve, reject) {
                 function cb(err, data) {
                     if (err) {
                         reject(err);
@@ -60,9 +60,9 @@ var _convert = function(f) {
  *
  * @param {ModbusRTU} Modbus the ModbusRTU object.
  */
-var addPromiseAPI = function(Modbus) {
+const addPromiseAPI = function(Modbus) {
 
-    var cl = Modbus.prototype;
+    const cl = Modbus.prototype;
 
     // set/get unitID
     cl.setID = function(id) {this._unitID = Number(id);};

--- a/examples/async_server.js
+++ b/examples/async_server.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console, no-unused-vars, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var vector = {
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const vector = {
     getInputRegister: function(addr, unitID) {
         // Synchronous handling
         return addr;
@@ -59,7 +59,7 @@ var vector = {
 
 // set the server to answer for modbus requests
 console.log("ModbusTCP listening on modbus://0.0.0.0:8502");
-var serverTCP = new ModbusRTU.ServerTCP(vector, {
+const serverTCP = new ModbusRTU.ServerTCP(vector, {
     host: "0.0.0.0",
     port: 8502,
     debug: true,

--- a/examples/buffer.js
+++ b/examples/buffer.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 //client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})
@@ -27,9 +27,9 @@ function setClient() {
 function run() {
     client.readInputRegisters(4, 12)
         .then(function(d) {
-            var floatA = d.buffer.readFloatBE(0);
-            var floatB = d.buffer.readFloatBE(4);
-            var floatC = d.buffer.readFloatBE(8);
+            const floatA = d.buffer.readFloatBE(0);
+            const floatB = d.buffer.readFloatBE(4);
+            const floatC = d.buffer.readFloatBE(8);
             console.log("Receive:", floatA, floatB, floatC); })
         .catch(function(e) {
             console.log(e.message); })

--- a/examples/buffered_server.js
+++ b/examples/buffered_server.js
@@ -1,24 +1,24 @@
 /* eslint-disable no-console, no-unused-vars, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
 
-var coils = Buffer.alloc(160008, 0); // coils and discrete inputs
-var regsiters = Buffer.alloc(160008, 0); // input and holding registers
+const coils = Buffer.alloc(160008, 0); // coils and discrete inputs
+const regsiters = Buffer.alloc(160008, 0); // input and holding registers
 
-var unitId = 1;
-var minAddress = 0;
-var maxInputAddress = 10001;
-var maxAddress = 20001;
-var bufferFactor = 8;
+const unitId = 1;
+const minAddress = 0;
+const maxInputAddress = 10001;
+const maxAddress = 20001;
+const bufferFactor = 8;
 
 //     1...10000*  address - 1      Coils (outputs)    0   Read/Write
 // 10001...20000*  address - 10001  Discrete Inputs    01  Read
 // 30001...40000*  address - 30001  Input Registers    04  Read
 // 40001...50000*  address - 40001  Holding Registers  03  Read/Write
 
-var vector = {
+const vector = {
     getCoil: function(addr, unitID) { if (unitID === unitId && addr >= minAddress && addr < maxAddress) { return coils.readUInt8(addr * bufferFactor); } },
     getInputRegister: function(addr, unitID) { if (unitID === unitId && addr >= minAddress && addr < maxInputAddress) { return regsiters.readUInt16BE(addr * bufferFactor); } },
     getHoldingRegister: function(addr, unitID) { if (unitID === unitId && addr >= maxInputAddress && addr < maxAddress) { return regsiters.readUInt16BE(addr * bufferFactor); } },
@@ -29,7 +29,7 @@ var vector = {
 
 // set the server to answer for modbus requests
 console.log("ModbusTCP listening on modbus://0.0.0.0:8502");
-var serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
+const serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
 
 serverTCP.on("socketError", function(err) {
     console.error(err);

--- a/examples/buffertcp.js
+++ b/examples/buffertcp.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
 // NPort Gateway 801D NetPort
 client.connectTcpRTUBuffered("127.0.0.1", { port: 8502 })

--- a/examples/debug.js
+++ b/examples/debug.js
@@ -10,9 +10,9 @@
  */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 //client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})

--- a/examples/device-identification.js
+++ b/examples/device-identification.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
-var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
+const networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
 
 // open connection to a serial port
 //client.connectRTUBuffered("/dev/ttyUSB0", { hupcl: false, dsrdtr: false })

--- a/examples/logger.js
+++ b/examples/logger.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
-var timeoutRunRef = null;
-var timeoutConnectRef = null;
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+let client = new ModbusRTU();
+let timeoutRunRef = null;
+let timeoutConnectRef = null;
 
-var networkErrors = [
+const networkErrors = [
     "ESOCKETTIMEDOUT",
     "ETIMEDOUT",
     "ECONNRESET",

--- a/examples/logger_complete.js
+++ b/examples/logger_complete.js
@@ -1,16 +1,16 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
-var timeoutRunRefCoils = null;
-var timeoutRunRefDiscreteInputs = null;
-var timeoutRunRefInputs = null;
-var timeoutRunRefHoldings = null;
-var timeoutConnectRef = null;
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+let client = new ModbusRTU();
+let timeoutRunRefCoils = null;
+let timeoutRunRefDiscreteInputs = null;
+let timeoutRunRefInputs = null;
+let timeoutRunRefHoldings = null;
+let timeoutConnectRef = null;
 
-var networkErrors = [
+const networkErrors = [
     "ESOCKETTIMEDOUT",
     "ETIMEDOUT",
     "ECONNRESET",

--- a/examples/polling_RTU.js
+++ b/examples/polling_RTU.js
@@ -11,25 +11,25 @@
 
 //==============================================================
 // create an empty modbus client
-var ModbusRTU   = require ("modbus-serial");
-var client      = new ModbusRTU();
+const ModbusRTU   = require ("modbus-serial");
+const client      = new ModbusRTU();
 
-var mbsStatus   = "Initializing...";    // holds a status of Modbus
+let mbsStatus   = "Initializing...";    // holds a status of Modbus
 
 // Modbus 'state' constants
-var MBS_STATE_INIT          = "State init";
-var MBS_STATE_IDLE          = "State idle";
-var MBS_STATE_NEXT          = "State next";
-var MBS_STATE_GOOD_READ     = "State good (read)";
-var MBS_STATE_FAIL_READ     = "State fail (read)";
-var MBS_STATE_GOOD_CONNECT  = "State good (port)";
-var MBS_STATE_FAIL_CONNECT  = "State fail (port)";
+const MBS_STATE_INIT          = "State init";
+const MBS_STATE_IDLE          = "State idle";
+const MBS_STATE_NEXT          = "State next";
+const MBS_STATE_GOOD_READ     = "State good (read)";
+const MBS_STATE_FAIL_READ     = "State fail (read)";
+const MBS_STATE_GOOD_CONNECT  = "State good (port)";
+const MBS_STATE_FAIL_CONNECT  = "State fail (port)";
 
 // Modbus configuration values
-var mbsId       = 1;
-var mbsScan     = 1000;
-var mbsTimeout  = 5000;
-var mbsState    = MBS_STATE_INIT;
+const mbsId       = 1;
+const mbsScan     = 1000;
+const mbsTimeout  = 5000;
+let mbsState    = MBS_STATE_INIT;
 
 // Upon SerialPort error
 client.on("error", function(error) {
@@ -38,7 +38,7 @@ client.on("error", function(error) {
 
 
 //==============================================================
-var connectClient = function()
+const connectClient = function()
 {
     // set requests parameters
     client.setID      (mbsId);
@@ -62,7 +62,7 @@ var connectClient = function()
 
 
 //==============================================================
-var readModbusData = function()
+const readModbusData = function()
 {
     // try to read data
     client.readHoldingRegisters (5, 1)
@@ -82,9 +82,9 @@ var readModbusData = function()
 
 
 //==============================================================
-var runModbus = function()
+const runModbus = function()
 {
-    var nextAction;
+    let nextAction;
 
     switch (mbsState)
     {

--- a/examples/polling_TCP.js
+++ b/examples/polling_TCP.js
@@ -11,31 +11,31 @@
 
 //==============================================================
 // create an empty modbus client
-var ModbusRTU   = require ("modbus-serial");
-var client      = new ModbusRTU();
+const ModbusRTU   = require ("modbus-serial");
+const client      = new ModbusRTU();
 
-var mbsStatus   = "Initializing...";    // holds a status of Modbus
+let mbsStatus   = "Initializing...";    // holds a status of Modbus
 
 // Modbus 'state' constants
-var MBS_STATE_INIT          = "State init";
-var MBS_STATE_IDLE          = "State idle";
-var MBS_STATE_NEXT          = "State next";
-var MBS_STATE_GOOD_READ     = "State good (read)";
-var MBS_STATE_FAIL_READ     = "State fail (read)";
-var MBS_STATE_GOOD_CONNECT  = "State good (port)";
-var MBS_STATE_FAIL_CONNECT  = "State fail (port)";
+const MBS_STATE_INIT          = "State init";
+const MBS_STATE_IDLE          = "State idle";
+const MBS_STATE_NEXT          = "State next";
+const MBS_STATE_GOOD_READ     = "State good (read)";
+const MBS_STATE_FAIL_READ     = "State fail (read)";
+const MBS_STATE_GOOD_CONNECT  = "State good (port)";
+const MBS_STATE_FAIL_CONNECT  = "State fail (port)";
 
 // Modbus TCP configuration values
-var mbsId       = 1;
-var mbsPort     = 502;
-var mbsHost     = "192.168.20.2";
-var mbsScan     = 1000;
-var mbsTimeout  = 5000;
-var mbsState    = MBS_STATE_INIT;
+const mbsId       = 1;
+const mbsPort     = 502;
+const mbsHost     = "192.168.20.2";
+const mbsScan     = 1000;
+const mbsTimeout  = 5000;
+let mbsState    = MBS_STATE_INIT;
 
 
 //==============================================================
-var connectClient = function()
+const connectClient = function()
 {
     // close port (NOTE: important in order not to create multiple connections)
     client.close();
@@ -63,7 +63,7 @@ var connectClient = function()
 
 
 //==============================================================
-var readModbusData = function()
+const readModbusData = function()
 {
     // try to read data
     client.readHoldingRegisters (0, 18)
@@ -83,9 +83,9 @@ var readModbusData = function()
 
 
 //==============================================================
-var runModbus = function()
+const runModbus = function()
 {
-    var nextAction;
+    let nextAction;
 
     switch (mbsState)
     {

--- a/examples/polling_UDP.js
+++ b/examples/polling_UDP.js
@@ -11,31 +11,31 @@
 
 //==============================================================
 // create an empty modbus client
-var ModbusRTU   = require ("modbus-serial");
-var client      = new ModbusRTU();
+const ModbusRTU   = require ("modbus-serial");
+const client      = new ModbusRTU();
 
-var mbsStatus   = "Initializing...";    // holds a status of Modbus
+let mbsStatus   = "Initializing...";    // holds a status of Modbus
 
 // Modbus 'state' constants
-var MBS_STATE_INIT          = "State init";
-var MBS_STATE_IDLE          = "State idle";
-var MBS_STATE_NEXT          = "State next";
-var MBS_STATE_GOOD_READ     = "State good (read)";
-var MBS_STATE_FAIL_READ     = "State fail (read)";
-var MBS_STATE_GOOD_CONNECT  = "State good (port)";
-var MBS_STATE_FAIL_CONNECT  = "State fail (port)";
+const MBS_STATE_INIT          = "State init";
+const MBS_STATE_IDLE          = "State idle";
+const MBS_STATE_NEXT          = "State next";
+const MBS_STATE_GOOD_READ     = "State good (read)";
+const MBS_STATE_FAIL_READ     = "State fail (read)";
+const MBS_STATE_GOOD_CONNECT  = "State good (port)";
+const MBS_STATE_FAIL_CONNECT  = "State fail (port)";
 
 // Modbus UDP configuration values
-var mbsId       = 1;
-var mbsPort     = 502;
-var mbsHost     = "192.168.1.11";
-var mbsScan     = 1000;
-var mbsTimeout  = 5000;
-var mbsState    = MBS_STATE_INIT;
+const mbsId       = 1;
+const mbsPort     = 502;
+const mbsHost     = "192.168.1.11";
+const mbsScan     = 1000;
+const mbsTimeout  = 5000;
+let mbsState    = MBS_STATE_INIT;
 
 
 //==============================================================
-var connectClient = function()
+const connectClient = function()
 {
     // close port (NOTE: important in order not to create multiple connections)
     client.close(() => {
@@ -65,7 +65,7 @@ var connectClient = function()
 
 
 //==============================================================
-var readModbusData = function()
+const readModbusData = function()
 {
     // try to read data
     client.readHoldingRegisters (0, 18)
@@ -85,9 +85,9 @@ var readModbusData = function()
 
 
 //==============================================================
-var runModbus = function()
+const runModbus = function()
 {
-    var nextAction;
+    let nextAction;
 
     switch (mbsState)
     {

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,21 +1,21 @@
 /* eslint-disable no-console, no-unused-vars, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var vector = {
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const vector = {
     getInputRegister: function(addr) { return addr; },
     getHoldingRegister: function(addr) { return addr + 8000; },
     getMultipleInputRegisters: function(startAddr, length) {
-        var values = [];
-        for (var i = 0; i < length; i++) {
+        const values = [];
+        for (let i = 0; i < length; i++) {
             values[i] = startAddr + i;
         }
         return values;
     },
     getMultipleHoldingRegisters: function(startAddr, length) {
-        var values = [];
-        for (var i = 0; i < length; i++) {
+        const values = [];
+        for (let i = 0; i < length; i++) {
             values[i] = startAddr + i + 8000;
         }
         return values;
@@ -37,7 +37,7 @@ var vector = {
 
 // set the server to answer for modbus requests
 console.log("ModbusTCP listening on modbus://0.0.0.0:8502");
-var serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
+const serverTCP = new ModbusRTU.ServerTCP(vector, { host: "0.0.0.0", port: 8502, debug: true, unitID: 1 });
 
 serverTCP.on("initialized", function() {
     console.log("initialized");

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
-var networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
+const networkErrors = ["ESOCKETTIMEDOUT", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EHOSTUNREACH"];
 
 // open connection to a serial port
 //client.connectRTUBuffered("/dev/ttyUSB0", { hupcl: false, dsrdtr: false })

--- a/examples/simple_ble.js
+++ b/examples/simple_ble.js
@@ -4,7 +4,7 @@ const { bluetooth } = require("webbluetooth");
 const ModbusRTU = require("../index");
 
 async function run() {
-    var client = new ModbusRTU();
+    const client = new ModbusRTU();
 
     await client.connectBle({
         bluetooth,

--- a/examples/write.js
+++ b/examples/write.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-//var ModbusRTU = require("modbus-serial");
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 //client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})

--- a/examples/write_complete.js
+++ b/examples/write_complete.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console, spaced-comment */
 
 // create an empty modbus client
-// var ModbusRTU = require("modbus-serial")
-var ModbusRTU = require("../index");
-var client = new ModbusRTU();
+// let ModbusRTU = require("modbus-serial")
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
 
 // open connection to a serial port
 // client.connectRTUBuffered("/dev/ttyUSB0", {baudRate: 9600})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var gulp = require("gulp");
-var pump = require("pump");
+const gulp = require("gulp");
+const pump = require("pump");
 const jsdoc = require("gulp-jsdoc3");
 const clean = require("gulp-clean");
 

--- a/index.js
+++ b/index.js
@@ -18,22 +18,22 @@
 /* Add bit operation functions to Buffer
  */
 require("./utils/buffer_bit")();
-var crc16 = require("./utils/crc16");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const crc16 = require("./utils/crc16");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
 
-var PORT_NOT_OPEN_MESSAGE = "Port Not Open";
-var PORT_NOT_OPEN_ERRNO = "ECONNREFUSED";
+const PORT_NOT_OPEN_MESSAGE = "Port Not Open";
+const PORT_NOT_OPEN_ERRNO = "ECONNREFUSED";
 
-var BAD_ADDRESS_MESSAGE = "Bad Client Address";
-var BAD_ADDRESS_ERRNO = "ECONNREFUSED";
+const BAD_ADDRESS_MESSAGE = "Bad Client Address";
+const BAD_ADDRESS_ERRNO = "ECONNREFUSED";
 
-var TRANSACTION_TIMED_OUT_MESSAGE = "Timed out";
-var TRANSACTION_TIMED_OUT_ERRNO = "ETIMEDOUT";
+const TRANSACTION_TIMED_OUT_MESSAGE = "Timed out";
+const TRANSACTION_TIMED_OUT_ERRNO = "ETIMEDOUT";
 
-var modbusErrorMessages = [
+const modbusErrorMessages = [
     "Unknown error",
     "Illegal function (device does not support this read/write function)",
     "Illegal data address (register not supported by device)",
@@ -43,27 +43,27 @@ var modbusErrorMessages = [
     "Slave device busy (retry request again later)"
 ];
 
-var PortNotOpenError = function() {
+const PortNotOpenError = function() {
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
     this.message = PORT_NOT_OPEN_MESSAGE;
     this.errno = PORT_NOT_OPEN_ERRNO;
 };
 
-var BadAddressError = function() {
+const BadAddressError = function() {
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
     this.message = BAD_ADDRESS_MESSAGE;
     this.errno = BAD_ADDRESS_ERRNO;
 };
 
-var TransactionTimedOutError = function() {
+const TransactionTimedOutError = function() {
     this.name = this.constructor.name;
     this.message = TRANSACTION_TIMED_OUT_MESSAGE;
     this.errno = TRANSACTION_TIMED_OUT_ERRNO;
 };
 
-var SerialPortError = function() {
+const SerialPortError = function() {
     this.name = this.constructor.name;
     this.message = null;
     this.errno = "ECONNREFUSED";
@@ -86,13 +86,13 @@ var SerialPortError = function() {
  * @param {Function} next the function to call next.
  */
 function _readFC2(data, next) {
-    var length = data.readUInt8(2);
-    var contents = [];
+    const length = data.readUInt8(2);
+    const contents = [];
 
-    for (var i = 0; i < length; i++) {
-        var reg = data[i + 3];
+    for (let i = 0; i < length; i++) {
+        let reg = data[i + 3];
 
-        for (var j = 0; j < 8; j++) {
+        for (let j = 0; j < 8; j++) {
             contents.push((reg & 1) === 1);
             reg = reg >> 1;
         }
@@ -110,11 +110,11 @@ function _readFC2(data, next) {
  * @param {Function} next the function to call next.
  */
 function _readFC4(data, next) {
-    var length = data.readUInt8(2);
-    var contents = [];
+    const length = data.readUInt8(2);
+    const contents = [];
 
-    for (var i = 0; i < length; i += 2) {
-        var reg = data.readUInt16BE(i + 3);
+    for (let i = 0; i < length; i += 2) {
+        const reg = data.readUInt16BE(i + 3);
         contents.push(reg);
     }
 
@@ -130,8 +130,8 @@ function _readFC4(data, next) {
  * @param {Function} next the function to call next.
  */
 function _readFC5(data, next) {
-    var dataAddress = data.readUInt16BE(2);
-    var state = data.readUInt16BE(4);
+    const dataAddress = data.readUInt16BE(2);
+    const state = data.readUInt16BE(4);
 
     if (next)
         next(null, { "address": dataAddress, "state": (state === 0xff00) });
@@ -145,8 +145,8 @@ function _readFC5(data, next) {
  * @param {Function} next the function to call next.
  */
 function _readFC6(data, next) {
-    var dataAddress = data.readUInt16BE(2);
-    var value = data.readUInt16BE(4);
+    const dataAddress = data.readUInt16BE(2);
+    const value = data.readUInt16BE(4);
 
     if (next)
         next(null, { "address": dataAddress, "value": value });
@@ -160,8 +160,8 @@ function _readFC6(data, next) {
  * @param {Function} next the function to call next.
  */
 function _readFC16(data, next) {
-    var dataAddress = data.readUInt16BE(2);
-    var length = data.readUInt16BE(4);
+    const dataAddress = data.readUInt16BE(2);
+    const length = data.readUInt16BE(4);
 
     if (next)
         next(null, { "address": dataAddress, "length": length });
@@ -175,10 +175,10 @@ function _readFC16(data, next) {
  * @param {Function} next
  */
 function _readFC20(data,  next) {
-    var fileRespLength = parseInt(data.readUInt8(2));
-    var result = [];
-    for (var i = 5; i < fileRespLength + 5; i++) {
-        var reg = data.readUInt8(i);
+    const fileRespLength = parseInt(data.readUInt8(2));
+    const result = [];
+    for (let i = 5; i < fileRespLength + 5; i++) {
+        const reg = data.readUInt8(i);
         result.push(reg);
     }
     if(next)
@@ -194,18 +194,18 @@ function _readFC20(data,  next) {
  * @param {Function} next the function to call next.
  */
 function _readFC43(data, modbus, next) {
-    var address = parseInt(data.readUInt8(0));
-    var readDeviceIdCode = parseInt(data.readUInt8(3));
-    var conformityLevel = parseInt(data.readUInt8(4));
-    var moreFollows = parseInt(data.readUInt8(5));
-    var nextObjectId = parseInt(data.readUInt8(6));
-    var numOfObjects = parseInt(data.readUInt8(7));
+    const address = parseInt(data.readUInt8(0));
+    const readDeviceIdCode = parseInt(data.readUInt8(3));
+    const conformityLevel = parseInt(data.readUInt8(4));
+    const moreFollows = parseInt(data.readUInt8(5));
+    const nextObjectId = parseInt(data.readUInt8(6));
+    const numOfObjects = parseInt(data.readUInt8(7));
 
-    var startAt = 8;
-    var result = {};
-    for (var i = 0; i < numOfObjects; i++) {
-        var objectId = parseInt(data.readUInt8(startAt));
-        var objectLength = parseInt(data.readUInt8(startAt + 1));
+    let startAt = 8;
+    const result = {};
+    for (let i = 0; i < numOfObjects; i++) {
+        const objectId = parseInt(data.readUInt8(startAt));
+        const objectLength = parseInt(data.readUInt8(startAt + 1));
         const startOfData = startAt + 2;
         result[objectId] = data.toString("ascii", startOfData, startOfData + objectLength);
         startAt = startOfData + objectLength;
@@ -230,7 +230,7 @@ function _readFC43(data, modbus, next) {
  * @private
  */
 function _writeBufferToPort(buffer, transactionId) {
-    var transaction = this._transactions[transactionId];
+    const transaction = this._transactions[transactionId];
 
     if (transaction) {
         transaction._timeoutFired = false;
@@ -261,7 +261,7 @@ function _startTimeout(duration, transaction) {
     return setTimeout(function() {
         transaction._timeoutFired = true;
         if (transaction.next) {
-            var err = new TransactionTimedOutError();
+            const err = new TransactionTimedOutError();
             if (transaction.request && transaction.responses) {
                 err.modbusRequest = transaction.request;
                 err.modbusResponses = transaction.responses;
@@ -288,11 +288,11 @@ function _cancelTimeout(timeoutHandle) {
  * @private
  */
 function _onReceive(data) {
-    var modbus = this;
-    var error;
+    const modbus = this;
+    let error;
 
     // set locale helpers variables
-    var transaction = modbus._transactions[modbus._port._transactionIdRead];
+    const transaction = modbus._transactions[modbus._port._transactionIdRead];
 
     // the _transactionIdRead can be missing, ignore wrong transaction it's
     if (!transaction) {
@@ -305,7 +305,7 @@ function _onReceive(data) {
     }
 
     /* What do we do next? */
-    var next = function(err, res) {
+    const next = function(err, res) {
         if (transaction.next) {
             /* Include request/response data if enabled */
             if (transaction.request && transaction.responses) {
@@ -350,7 +350,7 @@ function _onReceive(data) {
     /* check message CRC
      * if CRC is bad raise an error
      */
-    var crcIn = data.readUInt16LE(data.length - 2);
+    const crcIn = data.readUInt16LE(data.length - 2);
     if (crcIn !== crc16(data.slice(0, -2))) {
         error = "CRC error";
         next(new Error(error));
@@ -358,14 +358,14 @@ function _onReceive(data) {
     }
 
     // if crc is OK, read address and function code
-    var address = data.readUInt8(0);
-    var code = data.readUInt8(1);
+    const address = data.readUInt8(0);
+    const code = data.readUInt8(1);
 
     /* check for modbus exception
      */
     if (data.length >= 5 &&
         code === (0x80 | transaction.nextCode)) {
-        var errorCode = data.readUInt8(2);
+        const errorCode = data.readUInt8(2);
         if (transaction.next) {
             error = new Error("Modbus exception " + errorCode + ": " + (modbusErrorMessages[errorCode] || "Unknown error"));
             error.modbusCode = errorCode;
@@ -455,7 +455,7 @@ function _onReceive(data) {
  * @private
  */
 function _onError(e) {
-    var err = new SerialPortError();
+    const err = new SerialPortError();
     err.message = e.message;
     err.stack = e.stack;
     this.emit("error", err);
@@ -493,7 +493,7 @@ class ModbusRTU extends EventEmitter {
      *      of failure.
      */
     open(callback) {
-        var modbus = this;
+        const modbus = this;
 
         // open the serial port
         modbus._port.open(function(error) {
@@ -624,8 +624,8 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var codeLength = 6;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 6;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -683,8 +683,8 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var codeLength = 6;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 6;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -719,7 +719,7 @@ class ModbusRTU extends EventEmitter {
             return;
         }
 
-        var code = 5;
+        const code = 5;
 
         // set state variables
         this._transactions[this._port._transactionIdWrite] = {
@@ -729,8 +729,8 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var codeLength = 6;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 6;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -770,7 +770,7 @@ class ModbusRTU extends EventEmitter {
             return;
         }
 
-        var code = 6;
+        const code = 6;
 
         // set state variables
         this._transactions[this._port._transactionIdWrite] = {
@@ -780,8 +780,8 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var codeLength = 6; // 1B deviceAddress + 1B functionCode + 2B dataAddress + 2B value
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 6; // 1B deviceAddress + 1B functionCode + 2B dataAddress + 2B value
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -821,8 +821,8 @@ class ModbusRTU extends EventEmitter {
             return;
         }
 
-        var code = 15;
-        var i = 0;
+        const code = 15;
+        let i = 0;
 
         // set state variables
         this._transactions[this._port._transactionIdWrite] = {
@@ -832,9 +832,9 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var dataBytes = Math.ceil(array.length / 8);
-        var codeLength = 7 + dataBytes;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const dataBytes = Math.ceil(array.length / 8);
+        const codeLength = 7 + dataBytes;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -883,7 +883,7 @@ class ModbusRTU extends EventEmitter {
             return;
         }
 
-        var code = 16;
+        const code = 16;
 
         // set state variables
         this._transactions[this._port._transactionIdWrite] = {
@@ -893,14 +893,14 @@ class ModbusRTU extends EventEmitter {
             next: next
         };
 
-        var dataLength = array.length;
+        let dataLength = array.length;
         if (Buffer.isBuffer(array)) {
             // if array is a buffer it has double length
             dataLength = array.length / 2;
         }
 
-        var codeLength = 7 + 2 * dataLength;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 7 + 2 * dataLength;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
 
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
@@ -912,7 +912,7 @@ class ModbusRTU extends EventEmitter {
         if (Buffer.isBuffer(array)) {
             array.copy(buf, 7);
         } else {
-            for (var i = 0; i < dataLength; i++) {
+            for (let i = 0; i < dataLength; i++) {
                 buf.writeUInt16BE(array[i], 7 + 2 * i);
             }
         }
@@ -940,10 +940,10 @@ class ModbusRTU extends EventEmitter {
             return;
         }
         // function code defaults to 20
-        var code = 20;
-        var codeLength = 10;
-        var byteCount = 7;
-        var chunck = 100;
+        const code = 20;
+        const codeLength = 10;
+        const byteCount = 7;
+        const chunck = 100;
 
         this._transactions[this._port._transactionIdWrite] = {
             nextAddress: address,
@@ -951,7 +951,7 @@ class ModbusRTU extends EventEmitter {
             lengthUnknown: true,
             next: next
         };
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
         buf.writeUInt8(byteCount, 2);
@@ -978,7 +978,7 @@ class ModbusRTU extends EventEmitter {
             return;
         }
 
-        var code = 0x2B; // 43
+        const code = 0x2B; // 43
 
         // set state variables
         this._transactions[this._port._transactionIdWrite] = {
@@ -987,8 +987,8 @@ class ModbusRTU extends EventEmitter {
             lengthUnknown: true,
             next: next
         };
-        var codeLength = 5;
-        var buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        const codeLength = 5;
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
         buf.writeUInt8(0x0E, 2); // 16 MEI Type

--- a/ports/asciiport.js
+++ b/ports/asciiport.js
@@ -1,16 +1,16 @@
 "use strict";
 /* eslint-disable no-ternary */
 
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport").SerialPort;
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const SerialPort = require("serialport").SerialPort;
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var crc16 = require("../utils/crc16");
-var calculateLrc = require("./../utils/lrc");
+const crc16 = require("../utils/crc16");
+const calculateLrc = require("./../utils/lrc");
 
 /* TODO: const should be set once, maybe */
-var MIN_DATA_LENGTH = 6;
+const MIN_DATA_LENGTH = 6;
 
 /**
  * Ascii encode a 'request' buffer and return it. This includes removing
@@ -26,7 +26,7 @@ function _asciiEncodeRequestBuffer(buf) {
     buf.writeUInt8(calculateLrc(buf.slice(0, -2)), buf.length - 2);
 
     // create a new buffer of the correct size
-    var bufAscii = Buffer.alloc(buf.length * 2 + 1); // 1 byte start delimit + x2 data as ascii encoded + 2 lrc + 2 end delimit
+    const bufAscii = Buffer.alloc(buf.length * 2 + 1); // 1 byte start delimit + x2 data as ascii encoded + 2 lrc + 2 end delimit
 
     // create the ascii payload
 
@@ -51,18 +51,18 @@ function _asciiEncodeRequestBuffer(buf) {
 function _asciiDecodeResponseBuffer(bufAscii) {
 
     // create a new buffer of the correct size (based on ascii encoded buffer length)
-    var bufDecoded = Buffer.alloc((bufAscii.length - 1) / 2);
+    const bufDecoded = Buffer.alloc((bufAscii.length - 1) / 2);
 
     // decode into new buffer (removing delimiters at start and end)
-    for (var i = 0; i < (bufAscii.length - 3) / 2; i++) {
+    for (let i = 0; i < (bufAscii.length - 3) / 2; i++) {
         bufDecoded.write(String.fromCharCode(bufAscii.readUInt8(i * 2 + 1), bufAscii.readUInt8(i * 2 + 2)), i, 1, "hex");
     }
 
     // check the lrc is true
-    var lrcIn = bufDecoded.readUInt8(bufDecoded.length - 2);
+    const lrcIn = bufDecoded.readUInt8(bufDecoded.length - 2);
     if(calculateLrc(bufDecoded.slice(0, -2)) !== lrcIn) {
         // return null if lrc error
-        var calcLrc = calculateLrc(bufDecoded.slice(0, -2));
+        const calcLrc = calculateLrc(bufDecoded.slice(0, -2));
 
         modbusSerialDebug({ action: "LRC error", LRC: lrcIn.toString(16), calcLRC: calcLrc.toString(16) });
         return null;
@@ -107,7 +107,7 @@ class AsciiPort extends EventEmitter {
     constructor(path, options) {
         super();
 
-        var modbus = this;
+        const modbus = this;
 
         // options
         options = options || {};
@@ -140,7 +140,7 @@ class AsciiPort extends EventEmitter {
             modbusSerialDebug(JSON.stringify({ action: "receive serial ascii port strings", data: data, buffer: modbus._buffer }));
 
             // check buffer for start delimiter
-            var sdIndex = modbus._buffer.indexOf(modbus._startOfSlaveFrameChar);
+            const sdIndex = modbus._buffer.indexOf(modbus._startOfSlaveFrameChar);
             if(sdIndex === -1) {
                 // if not there, reset the buffer and return
                 modbus._buffer = Buffer.from("");
@@ -153,14 +153,14 @@ class AsciiPort extends EventEmitter {
             // do we have the complete message (i.e. are the end delimiters there)
             if(modbus._buffer.includes("\r\n", 1, "ascii") === true) {
                 // check there is no excess data after end delimiters
-                var edIndex = modbus._buffer.indexOf(0x0A); // ascii for '\n'
+                const edIndex = modbus._buffer.indexOf(0x0A); // ascii for '\n'
                 if(edIndex !== modbus._buffer.length - 1) {
                     // if there is, remove it
                     modbus._buffer = modbus._buffer.slice(0, edIndex + 1);
                 }
 
                 // we have what looks like a complete ascii encoded response message, so decode
-                var _data = _asciiDecodeResponseBuffer(modbus._buffer);
+                const _data = _asciiDecodeResponseBuffer(modbus._buffer);
                 modbusSerialDebug({ action: "got EOM", data: _data, buffer: modbus._buffer });
                 if(_data !== null) {
 
@@ -219,7 +219,7 @@ class AsciiPort extends EventEmitter {
             return;
         }
 
-        var length = null;
+        let length = null;
 
         // remember current unit and command
         this._id = data[0];
@@ -251,7 +251,7 @@ class AsciiPort extends EventEmitter {
         }
 
         // ascii encode buffer
-        var _encodedData = _asciiEncodeRequestBuffer(data);
+        const _encodedData = _asciiEncodeRequestBuffer(data);
 
         // send buffer to slave
         this._client.write(_encodedData);

--- a/ports/c701port.js
+++ b/ports/c701port.js
@@ -1,15 +1,15 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var dgram = require("dgram");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const dgram = require("dgram");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var crc16 = require("../utils/crc16");
+const crc16 = require("../utils/crc16");
 
 /* TODO: const should be set once, maybe */
-var MIN_DATA_LENGTH = 6;
+const MIN_DATA_LENGTH = 6;
 
-var C701_PORT = 0x7002;
+const C701_PORT = 0x7002;
 
 /**
  * Check if a buffer chunk can be a Modbus answer or modbus exception.
@@ -24,7 +24,7 @@ function _checkData(modbus, buf) {
     if (buf.length !== modbus._length && buf.length !== 5) return false;
 
     // calculate crc16
-    var crcIn = buf.readUInt16LE(buf.length - 2);
+    const crcIn = buf.readUInt16LE(buf.length - 2);
 
     // check buffer unit-id, command and crc
     return (buf[0] === modbus._id &&
@@ -43,7 +43,7 @@ class UdpPort extends EventEmitter {
     constructor(ip, options) {
         super();
 
-        var modbus = this;
+        const modbus = this;
         this.ip = ip;
         this.openFlag = false;
 
@@ -56,7 +56,7 @@ class UdpPort extends EventEmitter {
 
         // wait for answer
         this._client.on("message", function(data) {
-            var buffer = null;
+            let buffer = null;
 
             // check expected length
             if (modbus.length < 6) return;
@@ -149,7 +149,7 @@ class UdpPort extends EventEmitter {
             return;
         }
 
-        var length = null;
+        let length = null;
 
         // remember current unit and command
         this._id = data[0];
@@ -180,7 +180,7 @@ class UdpPort extends EventEmitter {
         }
 
         // build C701 header
-        var buffer = Buffer.alloc(data.length + 116);
+        const buffer = Buffer.alloc(data.length + 116);
         buffer.fill(0);
         buffer.writeUInt16LE(600, 2);           // C701 magic for serial bridge
         buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)

--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -1,17 +1,17 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var SerialPort = require("serialport").SerialPort;
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const SerialPort = require("serialport").SerialPort;
+const modbusSerialDebug = require("debug")("modbus-serial");
 
 /* TODO: const should be set once, maybe */
-var EXCEPTION_LENGTH = 5;
-var MIN_DATA_LENGTH = 6;
-var MAX_BUFFER_LENGTH = 256;
-var CRC_LENGTH = 2;
-var READ_DEVICE_IDENTIFICATION_FUNCTION_CODE = 43;
-var LENGTH_UNKNOWN = "unknown";
-var BITS_TO_NUM_OF_OBJECTS = 7;
+const EXCEPTION_LENGTH = 5;
+const MIN_DATA_LENGTH = 6;
+const MAX_BUFFER_LENGTH = 256;
+const CRC_LENGTH = 2;
+const READ_DEVICE_IDENTIFICATION_FUNCTION_CODE = 43;
+const LENGTH_UNKNOWN = "unknown";
+const BITS_TO_NUM_OF_OBJECTS = 7;
 
 // Helper function -> Bool
 // BIT | TYPE
@@ -19,16 +19,16 @@ var BITS_TO_NUM_OF_OBJECTS = 7;
 // 9 | length of OBJECTID
 // 10 -> n | the object
 // 10 + n + 1 | new object id
-var calculateFC43Length = function(buffer, numObjects, i, bufferLength) {
-    var result = { hasAllData: true };
-    var currentByte = 8 + i; // current byte starts at object id.
+const calculateFC43Length = function(buffer, numObjects, i, bufferLength) {
+    const result = { hasAllData: true };
+    let currentByte = 8 + i; // current byte starts at object id.
     if (numObjects > 0) {
-        for (var j = 0; j < numObjects; j++) {
+        for (let j = 0; j < numObjects; j++) {
             if (bufferLength < currentByte) {
                 result.hasAllData = false;
                 break;
             }
-            var objLength = buffer[currentByte + 1];
+            const objLength = buffer[currentByte + 1];
             if (!objLength) {
                 result.hasAllData = false;
                 break;
@@ -57,7 +57,7 @@ class RTUBufferedPort extends EventEmitter {
     constructor(path, options) {
         super();
 
-        var self = this;
+        const self = this;
 
         // options
         if (typeof(options) === "undefined") options = {};
@@ -87,8 +87,8 @@ class RTUBufferedPort extends EventEmitter {
             modbusSerialDebug({ action: "receive serial rtu buffered port", data: data, buffer: self._buffer });
 
             // check if buffer include a complete modbus answer
-            var expectedLength = self._length;
-            var bufferLength = self._buffer.length;
+            const expectedLength = self._length;
+            let bufferLength = self._buffer.length;
 
 
             // check data length
@@ -104,11 +104,11 @@ class RTUBufferedPort extends EventEmitter {
             }
 
             // loop and check length-sized buffer chunks
-            var maxOffset = bufferLength - EXCEPTION_LENGTH;
+            const maxOffset = bufferLength - EXCEPTION_LENGTH;
 
-            for (var i = 0; i <= maxOffset; i++) {
-                var unitId = self._buffer[i];
-                var functionCode = self._buffer[i + 1];
+            for (let i = 0; i <= maxOffset; i++) {
+                const unitId = self._buffer[i];
+                const functionCode = self._buffer[i + 1];
 
                 if (unitId !== self._id) continue;
 
@@ -116,8 +116,8 @@ class RTUBufferedPort extends EventEmitter {
                     if (bufferLength <= BITS_TO_NUM_OF_OBJECTS + i) {
                         return;
                     }
-                    var numObjects = self._buffer[7 + i];
-                    var result = calculateFC43Length(self._buffer, numObjects, i, bufferLength);
+                    const numObjects = self._buffer[7 + i];
+                    const result = calculateFC43Length(self._buffer, numObjects, i, bufferLength);
                     if (result.hasAllData) {
                         self._emitData(i, result.bufLength);
                         return;
@@ -156,7 +156,7 @@ class RTUBufferedPort extends EventEmitter {
      * @private
      */
     _emitData(start, length) {
-        var buffer = this._buffer.slice(start, start + length);
+        const buffer = this._buffer.slice(start, start + length);
         modbusSerialDebug({ action: "emit data serial rtu buffered port", buffer: buffer });
         this.emit("data", buffer);
         this._buffer = this._buffer.slice(start + length);
@@ -192,7 +192,7 @@ class RTUBufferedPort extends EventEmitter {
             return;
         }
 
-        var length = null;
+        let length = null;
 
         // remember current unit and command
         this._id = data[0];

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -1,17 +1,17 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var net = require("net");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const net = require("net");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var crc16 = require("../utils/crc16");
+const crc16 = require("../utils/crc16");
 
 /* TODO: const should be set once, maybe */
-var MODBUS_PORT = 502; // modbus port
-var MAX_TRANSACTIONS = 256; // maximum transaction to wait for
-var MIN_DATA_LENGTH = 6;
-var MIN_MBAP_LENGTH = 6;
-var CRC_LENGTH = 2;
+const MODBUS_PORT = 502; // modbus port
+const MAX_TRANSACTIONS = 256; // maximum transaction to wait for
+const MIN_DATA_LENGTH = 6;
+const MIN_MBAP_LENGTH = 6;
+const CRC_LENGTH = 2;
 
 class TcpPort extends EventEmitter {
     /**
@@ -27,7 +27,7 @@ class TcpPort extends EventEmitter {
     constructor(ip, options) {
         super();
 
-        var modbus = this;
+        const modbus = this;
         this.openFlag = false;
         this.callback = null;
         this._transactionIdWrite = 1;
@@ -57,7 +57,7 @@ class TcpPort extends EventEmitter {
 
         // handle callback - call a callback function only once, for the first event
         // it will triger
-        var handleCallback = function(had_error) {
+        const handleCallback = function(had_error) {
             if (modbus.callback) {
                 modbus.callback(had_error);
                 modbus.callback = null;
@@ -69,9 +69,9 @@ class TcpPort extends EventEmitter {
 
         if (options.timeout) this._client.setTimeout(options.timeout);
         this._client.on("data", function(data) {
-            var buffer;
-            var crc;
-            var length;
+            let buffer;
+            let crc;
+            let length;
 
             // data recived
             modbusSerialDebug({ action: "receive tcp port strings", data: data });
@@ -198,7 +198,7 @@ class TcpPort extends EventEmitter {
         this._cmd = data[1];
 
         // remove crc and add mbap
-        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        const buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
         buffer.writeUInt16BE(this._transactionIdWrite, 0);
         buffer.writeUInt16BE(0, 2);
         buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);

--- a/ports/tcprtubufferedport.js
+++ b/ports/tcprtubufferedport.js
@@ -1,20 +1,20 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var net = require("net");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const net = require("net");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var crc16 = require("../utils/crc16");
+const crc16 = require("../utils/crc16");
 
 /* TODO: const should be set once, maybe */
-var EXCEPTION_LENGTH = 3;
-var MIN_DATA_LENGTH = 6;
-var MIN_MBAP_LENGTH = 6;
-var MAX_TRANSACTIONS = 64; // maximum transaction to wait for
-var MAX_BUFFER_LENGTH = 256;
-var CRC_LENGTH = 2;
+const EXCEPTION_LENGTH = 3;
+const MIN_DATA_LENGTH = 6;
+const MIN_MBAP_LENGTH = 6;
+const MAX_TRANSACTIONS = 64; // maximum transaction to wait for
+const MAX_BUFFER_LENGTH = 256;
+const CRC_LENGTH = 2;
 
-var MODBUS_PORT = 502;
+const MODBUS_PORT = 502;
 
 class TcpRTUBufferedPort extends EventEmitter {
     /**
@@ -31,7 +31,7 @@ class TcpRTUBufferedPort extends EventEmitter {
     constructor(ip, options) {
         super();
 
-        var modbus = this;
+        const modbus = this;
         modbus.openFlag = false;
         modbus.callback = null;
         modbus._transactionIdWrite = 1;
@@ -63,7 +63,7 @@ class TcpRTUBufferedPort extends EventEmitter {
 
         // handle callback - call a callback function only once, for the first event
         // it will triger
-        var handleCallback = function(had_error) {
+        const handleCallback = function(had_error) {
             if (modbus.callback) {
                 modbus.callback(had_error);
                 modbus.callback = null;
@@ -86,7 +86,7 @@ class TcpRTUBufferedPort extends EventEmitter {
             });
 
             // check if buffer include a complete modbus answer
-            var bufferLength = modbus._buffer.length;
+            let bufferLength = modbus._buffer.length;
 
             // check data length
             if (bufferLength < MIN_MBAP_LENGTH) return;
@@ -101,12 +101,12 @@ class TcpRTUBufferedPort extends EventEmitter {
             if (bufferLength < MIN_MBAP_LENGTH + EXCEPTION_LENGTH) return;
 
             // loop and check length-sized buffer chunks
-            var maxOffset = bufferLength - MIN_MBAP_LENGTH;
-            for (var i = 0; i <= maxOffset; i++) {
+            const maxOffset = bufferLength - MIN_MBAP_LENGTH;
+            for (let i = 0; i <= maxOffset; i++) {
                 modbus._transactionIdRead = modbus._buffer.readUInt16BE(i);
-                var protocolID = modbus._buffer.readUInt16BE(i + 2);
-                var msgLength = modbus._buffer.readUInt16BE(i + 4);
-                var cmd = modbus._buffer[i + 7];
+                const protocolID = modbus._buffer.readUInt16BE(i + 2);
+                const msgLength = modbus._buffer.readUInt16BE(i + 4);
+                const cmd = modbus._buffer[i + 7];
 
                 modbusSerialDebug({
                     protocolID: protocolID,
@@ -170,18 +170,18 @@ class TcpRTUBufferedPort extends EventEmitter {
      * @private
      */
     _emitData(start, length) {
-        var modbus = this;
-        var data = modbus._buffer.slice(start, start + length);
+        const modbus = this;
+        const data = modbus._buffer.slice(start, start + length);
 
         // cut the buffer
         modbus._buffer = modbus._buffer.slice(start + length);
 
         if (data.length > 0) {
-            var buffer = Buffer.alloc(data.length + CRC_LENGTH);
+            const buffer = Buffer.alloc(data.length + CRC_LENGTH);
             data.copy(buffer, 0);
 
             // add crc
-            var crc = crc16(buffer.slice(0, -CRC_LENGTH));
+            const crc = crc16(buffer.slice(0, -CRC_LENGTH));
             buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
 
             modbus.emit("data", buffer);
@@ -253,7 +253,7 @@ class TcpRTUBufferedPort extends EventEmitter {
         }
 
         // remove crc and add mbap
-        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        const buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
         buffer.writeUInt16BE(this._transactionIdWrite, 0);
         buffer.writeUInt16BE(0, 2);
         buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);

--- a/ports/telnetport.js
+++ b/ports/telnetport.js
@@ -1,14 +1,14 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var net = require("net");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const net = require("net");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
 /* TODO: const should be set once, maybe */
-var EXCEPTION_LENGTH = 5;
-var MIN_DATA_LENGTH = 6;
+const EXCEPTION_LENGTH = 5;
+const MIN_DATA_LENGTH = 6;
 
-var TELNET_PORT = 2217;
+const TELNET_PORT = 2217;
 
 class TelnetPort extends EventEmitter {
     /**
@@ -21,7 +21,7 @@ class TelnetPort extends EventEmitter {
     constructor(ip, options) {
         super();
 
-        var self = this;
+        const self = this;
         this.ip = ip;
         this.openFlag = false;
         this.callback = null;
@@ -43,7 +43,7 @@ class TelnetPort extends EventEmitter {
 
         // handle callback - call a callback function only once, for the first event
         // it will triger
-        var handleCallback = function(had_error) {
+        const handleCallback = function(had_error) {
             if (self.callback) {
                 self.callback(had_error);
                 self.callback = null;
@@ -69,8 +69,8 @@ class TelnetPort extends EventEmitter {
             self._buffer = Buffer.concat([self._buffer, data]);
 
             // check if buffer include a complete modbus answer
-            var expectedLength = self._length;
-            var bufferLength = self._buffer.length;
+            const expectedLength = self._length;
+            const bufferLength = self._buffer.length;
             modbusSerialDebug(
                 "on data expected length:" +
                     expectedLength +
@@ -95,10 +95,10 @@ class TelnetPort extends EventEmitter {
             if (expectedLength < 6 || bufferLength < EXCEPTION_LENGTH) return;
 
             // loop and check length-sized buffer chunks
-            var maxOffset = bufferLength - EXCEPTION_LENGTH;
-            for (var i = 0; i <= maxOffset; i++) {
-                var unitId = self._buffer[i];
-                var functionCode = self._buffer[i + 1];
+            const maxOffset = bufferLength - EXCEPTION_LENGTH;
+            for (let i = 0; i <= maxOffset; i++) {
+                const unitId = self._buffer[i];
+                const functionCode = self._buffer[i + 1];
 
                 if (unitId !== self._id) continue;
 
@@ -227,7 +227,7 @@ class TelnetPort extends EventEmitter {
             return;
         }
 
-        var length = null;
+        let length = null;
 
         // remember current unit and command
         this._id = data[0];

--- a/ports/testport.js
+++ b/ports/testport.js
@@ -1,15 +1,15 @@
 /* eslint-disable class-methods-use-this */
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const modbusSerialDebug = require("debug")("modbus-serial");
 
 /* Add bit operation functions to Buffer
  */
 require("../utils/buffer_bit")();
-var crc16 = require("../utils/crc16");
+const crc16 = require("../utils/crc16");
 
-var MIN_DATA_LENGTH = 7;
+const MIN_DATA_LENGTH = 7;
 
 class TestPort extends EventEmitter {
     /**
@@ -70,21 +70,21 @@ class TestPort extends EventEmitter {
      * @param {Buffer} data
      */
     write(data) {
-        var buffer = null;
-        var length = null;
-        var address = null;
-        var value = null;
-        var state = null;
-        var i = null;
+        let buffer = null;
+        let length = null;
+        let address = null;
+        let value = null;
+        let state = null;
+        let i = null;
 
         if(data.length < MIN_DATA_LENGTH) {
             modbusSerialDebug("expected length of data is to small - minimum is " + MIN_DATA_LENGTH);
             return;
         }
 
-        var unitNumber = data[0];
-        var functionCode = data[1];
-        var crc = data[data.length - 2] + data[data.length - 1] * 0x100;
+        const unitNumber = data[0];
+        const functionCode = data[1];
+        let crc = data[data.length - 2] + data[data.length - 1] * 0x100;
         // if crc is bad, ignore message
         if (crc !== crc16(data.slice(0, -2))) {
             return;

--- a/ports/udpport.js
+++ b/ports/udpport.js
@@ -1,17 +1,17 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
-var dgram = require("dgram");
-var modbusSerialDebug = require("debug")("modbus-serial");
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
+const dgram = require("dgram");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
-var crc16 = require("../utils/crc16");
+const crc16 = require("../utils/crc16");
 
 /* TODO: const should be set once, maybe */
-var MODBUS_PORT = 502; // modbus port
-var MAX_TRANSACTIONS = 256; // maximum transaction to wait for
-var MIN_DATA_LENGTH = 6;
-var MIN_MBAP_LENGTH = 6;
-var CRC_LENGTH = 2;
+const MODBUS_PORT = 502; // modbus port
+const MAX_TRANSACTIONS = 256; // maximum transaction to wait for
+const MIN_DATA_LENGTH = 6;
+const MIN_MBAP_LENGTH = 6;
+const CRC_LENGTH = 2;
 
 class ModbusUdpPort extends EventEmitter {
     /**
@@ -24,7 +24,7 @@ class ModbusUdpPort extends EventEmitter {
     constructor(ip, options) {
         super();
 
-        var modbus = this;
+        const modbus = this;
         this.ip = ip;
         this.openFlag = false;
         this._transactionIdWrite = 1;
@@ -42,9 +42,9 @@ class ModbusUdpPort extends EventEmitter {
         // wait for answer
         const self = this;
         this._client.on("message", function(data, rinfo) {
-            var buffer;
-            var crc;
-            var length;
+            let buffer;
+            let crc;
+            let length;
 
             // Filter stuff not intended for us
             if(rinfo.address !== self.ip || rinfo.port !== self.port)
@@ -136,7 +136,7 @@ class ModbusUdpPort extends EventEmitter {
         this._cmd = data[1];
 
         // remove crc and add mbap
-        var buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
+        const buffer = Buffer.alloc(data.length + MIN_MBAP_LENGTH - CRC_LENGTH);
         buffer.writeUInt16BE(this._transactionIdWrite, 0);
         buffer.writeUInt16BE(0, 2);
         buffer.writeUInt16BE(data.length - CRC_LENGTH, 4);

--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 "use strict";
 /**
  * Copyright (c) 2017, Yaacov Zamir <kobi.zamir@gmail.com>
@@ -15,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF  THIS SOFTWARE.
  */
 
-var modbusSerialDebug = require("debug")("modbus-serial");
+const modbusSerialDebug = require("debug")("modbus-serial");
 
 /**
  * Check the length of request Buffer for length of 8.
@@ -68,16 +69,16 @@ function _handlePromiseOrValue(promiseOrValue, cb) {
  * @private
  */
 function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callback, fc) {
-    var address = requestBuffer.readUInt16BE(2);
-    var length = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const length = requestBuffer.readUInt16BE(4);
 
     if (_errorRequestBufferLength(requestBuffer)) {
         return;
     }
 
     // build answer
-    var dataBytes = parseInt((length - 1) / 8 + 1);
-    var responseBuffer = Buffer.alloc(3 + dataBytes + 2);
+    const dataBytes = parseInt((length - 1) / 8 + 1);
+    const responseBuffer = Buffer.alloc(3 + dataBytes + 2);
     try {
         responseBuffer.writeUInt8(dataBytes, 2);
     }
@@ -86,14 +87,14 @@ function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callbac
         return;
     }
 
-    var isGetCoil = (fc === 1 && vector.getCoil);
-    var isGetDiscreteInpupt = (fc === 2 && vector.getDiscreteInput);
+    const isGetCoil = (fc === 1 && vector.getCoil);
+    const isGetDiscreteInpupt = (fc === 2 && vector.getDiscreteInput);
 
     // read coils
     if (isGetCoil || isGetDiscreteInpupt) {
-        var callbackInvoked = false;
-        var cbCount = 0;
-        var buildCb = function(i) {
+        let callbackInvoked = false;
+        let cbCount = 0;
+        const buildCb = function(i) {
             return function(err, value) {
                 if (err) {
                     if (!callbackInvoked) {
@@ -123,9 +124,9 @@ function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callbac
                 msg: "Invalid length"
             });
 
-        var i = 0;
-        var cb = null;
-        var promiseOrValue = null;
+        let i = 0;
+        let cb = null;
+        let promiseOrValue = null;
 
         if (isGetCoil && vector.getCoil.length === 3) {
             for (i = 0; i < length; i++) {
@@ -187,15 +188,15 @@ function _handleReadCoilsOrInputDiscretes(requestBuffer, vector, unitID, callbac
  * @private
  */
 function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var length = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const length = requestBuffer.readUInt16BE(4);
 
     if (_errorRequestBufferLength(requestBuffer)) {
         return;
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
+    const responseBuffer = Buffer.alloc(3 + length * 2 + 2);
     try {
         responseBuffer.writeUInt8(length * 2, 2);
     }
@@ -204,9 +205,9 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
         return;
     }
 
-    var callbackInvoked = false;
-    var cbCount = 0;
-    var buildCb = function(i) {
+    let callbackInvoked = false;
+    let cbCount = 0;
+    const buildCb = function(i) {
         return function(err, value) {
             if (err) {
                 if (!callbackInvoked) {
@@ -238,9 +239,9 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
 
     // read registers
     function tryAndHandlePromiseOrValue(i, values) {
-        var cb = buildCb(i);
+        const cb = buildCb(i);
         try {
-            var promiseOrValue = values[i];
+            const promiseOrValue = values[i];
             _handlePromiseOrValue(promiseOrValue, cb);
         }
         catch (err) {
@@ -253,7 +254,7 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
         if (vector.getMultipleHoldingRegisters.length === 4) {
             vector.getMultipleHoldingRegisters(address, length, unitID, function(err, values) {
                 if (!err && values.length !== length) {
-                    var error = new Error("Requested address length and response length do not match");
+                    const error = new Error("Requested address length and response length do not match");
                     callback(error);
                 } else if (err) {
                     const cb = buildCb(i);
@@ -277,13 +278,13 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
                 }
             });
         } else {
-            var values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            const values = vector.getMultipleHoldingRegisters(address, length, unitID);
             if (values.length === length) {
                 for (i = 0; i < length; i++) {
                     tryAndHandlePromiseOrValue(i, values);
                 }
             } else {
-                var error = new Error("Requested address length and response length do not match");
+                const error = new Error("Requested address length and response length do not match");
                 callback(error);
             }
         }
@@ -291,12 +292,12 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
     }
     else if (vector.getHoldingRegister) {
         for (var i = 0; i < length; i++) {
-            var cb = buildCb(i);
+            const cb = buildCb(i);
             try {
                 if (vector.getHoldingRegister.length === 3) {
                     vector.getHoldingRegister(address + i, unitID, cb);
                 } else {
-                    var promiseOrValue = vector.getHoldingRegister(address + i, unitID);
+                    const promiseOrValue = vector.getHoldingRegister(address + i, unitID);
                     _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
@@ -320,15 +321,15 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
  * @private
  */
 function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var length = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const length = requestBuffer.readUInt16BE(4);
 
     if (_errorRequestBufferLength(requestBuffer)) {
         return;
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(3 + length * 2 + 2);
+    const responseBuffer = Buffer.alloc(3 + length * 2 + 2);
     try {
         responseBuffer.writeUInt8(length * 2, 2);
     }
@@ -337,9 +338,9 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
         return;
     }
 
-    var callbackInvoked = false;
-    var cbCount = 0;
-    var buildCb = function(i) {
+    let callbackInvoked = false;
+    let cbCount = 0;
+    const buildCb = function(i) {
         return function(err, value) {
             if (err) {
                 if (!callbackInvoked) {
@@ -370,9 +371,9 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
         });
 
     function tryAndHandlePromiseOrValues(i, values) {
-        var cb = buildCb(i);
+        const cb = buildCb(i);
         try {
-            var promiseOrValue = values[i];
+            const promiseOrValue = values[i];
             _handlePromiseOrValue(promiseOrValue, cb);
         }
         catch (err) {
@@ -385,11 +386,11 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
         if (vector.getMultipleInputRegisters.length === 4) {
             vector.getMultipleInputRegisters(address, length, unitID, function(err, values) {
                 if (!err && values.length !== length) {
-                    var error = new Error("Requested address length and response length do not match");
+                    const error = new Error("Requested address length and response length do not match");
                     callback(error);
                 } else {
-                    for (var i = 0; i < length; i++) {
-                        var cb = buildCb(i);
+                    for (let i = 0; i < length; i++) {
+                        const cb = buildCb(i);
                         try {
                             cb(err, values[i]);
                         }
@@ -400,13 +401,13 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
                 }
             });
         } else {
-            var values = vector.getMultipleInputRegisters(address, length, unitID);
+            const values = vector.getMultipleInputRegisters(address, length, unitID);
             if (values.length === length) {
                 for (var i = 0; i < length; i++) {
                     tryAndHandlePromiseOrValues(i, values);
                 }
             } else {
-                var error = new Error("Requested address length and response length do not match");
+                const error = new Error("Requested address length and response length do not match");
                 callback(error);
             }
         }
@@ -415,13 +416,13 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
     else if (vector.getInputRegister) {
 
         for (i = 0; i < length; i++) {
-            var cb = buildCb(i);
+            const cb = buildCb(i);
             try {
                 if (vector.getInputRegister.length === 3) {
                     vector.getInputRegister(address + i, unitID, cb);
                 }
                 else {
-                    var promiseOrValue = vector.getInputRegister(address + i, unitID);
+                    const promiseOrValue = vector.getInputRegister(address + i, unitID);
                     _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
@@ -443,21 +444,21 @@ function _handleReadInputRegisters(requestBuffer, vector, unitID, callback) {
  * @private
  */
 function _handleWriteCoil(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var state = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const state = requestBuffer.readUInt16BE(4);
 
     if (_errorRequestBufferLength(requestBuffer)) {
         return;
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(8);
+    const responseBuffer = Buffer.alloc(8);
     responseBuffer.writeUInt16BE(address, 2);
     responseBuffer.writeUInt16BE(state, 4);
 
     if (vector.setCoil) {
-        var callbackInvoked = false;
-        var cb = function(err) {
+        let callbackInvoked = false;
+        const cb = function(err) {
             if (err) {
                 if (!callbackInvoked) {
                     callbackInvoked = true;
@@ -480,7 +481,7 @@ function _handleWriteCoil(requestBuffer, vector, unitID, callback) {
                 vector.setCoil(address, state === 0xff00, unitID, cb);
             }
             else {
-                var promiseOrValue = vector.setCoil(address, state === 0xff00, unitID);
+                const promiseOrValue = vector.setCoil(address, state === 0xff00, unitID);
                 _handlePromiseOrValue(promiseOrValue, cb);
             }
         }
@@ -501,21 +502,21 @@ function _handleWriteCoil(requestBuffer, vector, unitID, callback) {
  * @private
  */
 function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var value = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const value = requestBuffer.readUInt16BE(4);
 
     if (_errorRequestBufferLength(requestBuffer)) {
         return;
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(8);
+    const responseBuffer = Buffer.alloc(8);
     responseBuffer.writeUInt16BE(address, 2);
     responseBuffer.writeUInt16BE(value, 4);
 
     if (vector.setRegister) {
-        var callbackInvoked = false;
-        var cb = function(err) {
+        let callbackInvoked = false;
+        const cb = function(err) {
             if (err) {
                 if (!callbackInvoked) {
                     callbackInvoked = true;
@@ -538,7 +539,7 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
                 vector.setRegister(address, value, unitID, cb);
             }
             else {
-                var promiseOrValue = vector.setRegister(address, value, unitID);
+                const promiseOrValue = vector.setRegister(address, value, unitID);
                 _handlePromiseOrValue(promiseOrValue, cb);
             }
         } catch(err) {
@@ -558,8 +559,8 @@ function _handleWriteSingleRegister(requestBuffer, vector, unitID, callback) {
  * @private
  */
 function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var length = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const length = requestBuffer.readUInt16BE(4);
 
     // if length is bad, ignore message
     if (requestBuffer.length !== 7 + Math.ceil(length / 8) + 2) {
@@ -567,13 +568,13 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(8);
+    const responseBuffer = Buffer.alloc(8);
     responseBuffer.writeUInt16BE(address, 2);
     responseBuffer.writeUInt16BE(length, 4);
 
-    var callbackInvoked = false;
-    var cbCount = 0;
-    var buildCb = function(/* i - not used at the moment */) {
+    let callbackInvoked = false;
+    let cbCount = 0;
+    const buildCb = function(/* i - not used at the moment */) {
         return function(err) {
             if (err) {
                 if (!callbackInvoked) {
@@ -602,7 +603,7 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
         });
 
     if (vector.setCoilArray) {
-        var state = [];
+        const state = [];
 
         for (i = 0; i < length; i++) {
             cb = buildCb(i);
@@ -654,8 +655,8 @@ function _handleForceMultipleCoils(requestBuffer, vector, unitID, callback) {
  * @private
  */
 function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) {
-    var address = requestBuffer.readUInt16BE(2);
-    var length = requestBuffer.readUInt16BE(4);
+    const address = requestBuffer.readUInt16BE(2);
+    const length = requestBuffer.readUInt16BE(4);
 
     // if length is bad, ignore message
     if (requestBuffer.length !== (7 + length * 2 + 2)) {
@@ -663,14 +664,14 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
     }
 
     // build answer
-    var responseBuffer = Buffer.alloc(8);
+    const responseBuffer = Buffer.alloc(8);
     responseBuffer.writeUInt16BE(address, 2);
     responseBuffer.writeUInt16BE(length, 4);
 
     // write registers
-    var callbackInvoked = false;
-    var cbCount = 0;
-    var buildCb = function(/* i - not used at the moment */) {
+    let callbackInvoked = false;
+    let cbCount = 0;
+    const buildCb = function(/* i - not used at the moment */) {
         return function(err) {
             if (err) {
                 if (!callbackInvoked) {
@@ -730,7 +731,7 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
                     vector.setRegister(address + i, value, unitID, cb);
                 }
                 else {
-                    var promiseOrValue = vector.setRegister(address + i, value, unitID);
+                    const promiseOrValue = vector.setRegister(address + i, value, unitID);
                     _handlePromiseOrValue(promiseOrValue, cb);
                 }
             }
@@ -752,7 +753,7 @@ function _handleWriteMultipleRegisters(requestBuffer, vector, unitID, callback) 
  * @private
  */
 function _handleMEI(requestBuffer, vector, unitID, callback) {
-    var MEIType = requestBuffer[2];
+    const MEIType = requestBuffer[2];
     switch(parseInt(MEIType)) {
         case 14:
             _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback);
@@ -782,8 +783,8 @@ function _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback
         return;
     }
 
-    var readDeviceIDCode = requestBuffer.readUInt8(3);
-    var objectID = requestBuffer.readUInt8(4);
+    const readDeviceIDCode = requestBuffer.readUInt8(3);
+    let objectID = requestBuffer.readUInt8(4);
 
     // Basic request parameters checks
     switch(readDeviceIDCode) {
@@ -815,7 +816,7 @@ function _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback
     }
 
     // Filling mandatory basic device identification objects
-    var objects = {
+    const objects = {
         0x00: "undefined",
         0x01: "undefined",
         0x02: "undefined"
@@ -831,16 +832,16 @@ function _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback
             objects[0x02] = pkg.version;
     }
 
-    var promiseOrValue = vector.readDeviceIdentification(unitID);
+    const promiseOrValue = vector.readDeviceIdentification(unitID);
     _handlePromiseOrValue(promiseOrValue, function(err, value) {
         if(err) {
             callback(err);
             return;
         }
 
-        var userObjects = value;
+        const userObjects = value;
 
-        for(var o of Object.keys(userObjects)) {
+        for(const o of Object.keys(userObjects)) {
             const i = parseInt(o);
             if(!isNaN(i) && i >= 0 && i <= 255)
                 objects[i] = userObjects[o];
@@ -856,12 +857,12 @@ function _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback
             objectID = 0x00;
         }
 
-        var ids = [];
-        var totalLength = 2 + MEI14HeaderLen + 2; // UnitID + FC + MEI14Header + CRC
-        var lastID = 0;
-        var conformityLevel = 0x81;
+        const ids = [];
+        let totalLength = 2 + MEI14HeaderLen + 2; // UnitID + FC + MEI14Header + CRC
+        let lastID = 0;
+        let conformityLevel = 0x81;
 
-        var supportedIDs = Object.keys(objects);
+        const supportedIDs = Object.keys(objects);
 
         // Filtering of objects and Conformity level determination
         for(var id of supportedIDs) {
@@ -909,9 +910,9 @@ function _handleReadDeviceIdentification(requestBuffer, vector, unitID, callback
         }
 
         ids.sort((a, b) => parseInt(a) - parseInt(b));
-        var responseBuffer = Buffer.alloc(totalLength);
+        const responseBuffer = Buffer.alloc(totalLength);
 
-        var i = 2;
+        let i = 2;
         i = responseBuffer.writeUInt8(14, i);                                   // MEI type
         i = responseBuffer.writeUInt8(readDeviceIDCode, i);
         i = responseBuffer.writeUInt8(conformityLevel, i);

--- a/test/Lint/test.js
+++ b/test/Lint/test.js
@@ -1,9 +1,9 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var lint = require("mocha-eslint");
+const lint = require("mocha-eslint");
 
-var paths = [
+const paths = [
     "index.js",
     "ports/**/*.js",
     "servers/**/*.js",
@@ -13,7 +13,7 @@ var paths = [
     "test/**/*.js"
 ];
 
-var options = {
+const options = {
     // Specify style of output
     formatter: "compact", // Defaults to `stylish`
     timeout: 5000

--- a/test/apis/promise.js
+++ b/test/apis/promise.js
@@ -1,22 +1,22 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var ModbusRTU = require("../../index");
-var TestPort = ModbusRTU.TestPort;
-var testPort = new TestPort();
-var modbusRTU = new ModbusRTU(testPort);
+const ModbusRTU = require("../../index");
+const TestPort = ModbusRTU.TestPort;
+const testPort = new TestPort();
+const modbusRTU = new ModbusRTU(testPort);
 
-var expect = require("chai").expect;
+const expect = require("chai").expect;
 
 describe("Promise", function() {
 
     describe("Functions", function() {
         it("should bind promise functions on modbusRTU", function() {
-            var address = 1;
-            var arg = 1;
-            var value = 1;
-            var deviceIdCode = 1;
-            var objectId = 2;
+            const address = 1;
+            const arg = 1;
+            const value = 1;
+            const deviceIdCode = 1;
+            const objectId = 2;
 
             modbusRTU.open();
             expect(modbusRTU.readCoils(address, arg)).to.be.instanceOf(Promise);
@@ -32,7 +32,7 @@ describe("Promise", function() {
 
     describe("#setID", function() {
         it("should set a unit id on modubusRtu instance", function() {
-            var someId = 1;
+            const someId = 1;
             modbusRTU.setID(someId);
             expect(modbusRTU._unitID).to.be.equal(someId);
         });
@@ -40,7 +40,7 @@ describe("Promise", function() {
 
     describe("#getID", function() {
         it("should return the unit id of modubusRtu instance", function() {
-            var someId = 1;
+            const someId = 1;
             modbusRTU._unitID = someId;
             expect(modbusRTU.getID()).to.be.equal(someId);
         });
@@ -48,7 +48,7 @@ describe("Promise", function() {
 
     describe("#setTimeout", function() {
         it("should set a timeout on modubusRtu instance", function() {
-            var timeout = 1000;
+            const timeout = 1000;
             modbusRTU.setTimeout(timeout);
             expect(modbusRTU._timeout).to.be.equal(timeout);
         });

--- a/test/mocks/SerialPortMock.js
+++ b/test/mocks/SerialPortMock.js
@@ -1,6 +1,6 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
 
 class SerialPortMock extends EventEmitter {
     /**

--- a/test/mocks/dgramMock.js
+++ b/test/mocks/dgramMock.js
@@ -1,6 +1,6 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
 
 class Socket extends EventEmitter {
     connect(port, host, connectListener) {

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -1,6 +1,6 @@
 "use strict";
-var events = require("events");
-var EventEmitter = events.EventEmitter || events;
+const events = require("events");
+const EventEmitter = events.EventEmitter || events;
 
 class Socket extends EventEmitter {
     constructor() {

--- a/test/ports/asciiport.test.js
+++ b/test/ports/asciiport.test.js
@@ -1,23 +1,23 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
-var LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
+const LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
 1830183018301830183018301830183018301830183018301830183018301830183018301830183\
 0183018301830183018301830183018301830183018301830183018301830183018301830183018\
 3018301830183018301830183018301830183018346e0";
 
 describe("Modbus Ascii port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("./../mocks/SerialPortMock");
+        const mock = require("./../mocks/SerialPortMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("serialport", mock);
-        var AsciiPort = require("./../../ports/asciiport");
+        const AsciiPort = require("./../../ports/asciiport");
         port = new AsciiPort(
             "/dev/null",
             { startOfSlaveFrameChar: 0x3E }  // optional slave frame char ('>')
@@ -106,7 +106,7 @@ describe("Modbus Ascii port", function() {
                 port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
                     port._client.receive(Buffer.from(">", "ascii"));
-                    for (var i = 0; i < (LONG_MSG.length - 4); i += 2) {
+                    for (let i = 0; i < (LONG_MSG.length - 4); i += 2) {
                         port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "ascii"));
                     }
                     port._client.receive(Buffer.from("7C", "ascii"));

--- a/test/ports/c701port.test.js
+++ b/test/ports/c701port.test.js
@@ -1,18 +1,18 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
 describe("Modbus UDP port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("./../mocks/dgramMock");
+        const mock = require("./../mocks/dgramMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("dgram", mock);
-        var UdpPort = require("./../../ports/c701port");
+        const UdpPort = require("./../../ports/c701port");
         port = new UdpPort("127.0.0.1", { port: 9999 });
     });
 
@@ -58,7 +58,7 @@ describe("Modbus UDP port", function() {
                 port.write(Buffer.from("1103006B00037687", "hex"));
 
                 if (port._client._data.slice(-8).equals(Buffer.from("1103006B00037687", "hex"))) {
-                    var buffer = Buffer.alloc(116 + 11).fill(0);
+                    const buffer = Buffer.alloc(116 + 11).fill(0);
                     buffer.writeUInt16LE(602, 2);           // C701 magic for serial bridge
                     buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
                     buffer.writeUInt16LE(0, 38);            // expected serial answer length
@@ -81,7 +81,7 @@ describe("Modbus UDP port", function() {
                 port.write(Buffer.from("1103006B00037687", "hex"));
 
                 if (port._client._data.slice(-8).equals(Buffer.from("1103006B00037687", "hex"))) {
-                    var buffer = Buffer.alloc(116 + 5).fill(0);
+                    const buffer = Buffer.alloc(116 + 5).fill(0);
                     buffer.writeUInt16LE(602, 2);           // C701 magic for serial bridge
                     buffer.writeUInt16LE(0, 36);            // C701 RS485 connector (0..2)
                     buffer.writeUInt16LE(0, 38);            // expected serial answer length

--- a/test/ports/rtubufferedport.test.js
+++ b/test/ports/rtubufferedport.test.js
@@ -1,23 +1,23 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
-var LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
+const LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
 1830183018301830183018301830183018301830183018301830183018301830183018301830183\
 0183018301830183018301830183018301830183018301830183018301830183018301830183018\
 3018301830183018301830183018301830183018346e0";
 
 describe("Modbus RTU buffered port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("./../mocks/SerialPortMock");
+        const mock = require("./../mocks/SerialPortMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("serialport", mock);
-        var RTUBufferedPort = require("./../../ports/rtubufferedport");
+        const RTUBufferedPort = require("./../../ports/rtubufferedport");
         port = new RTUBufferedPort("/dev/null", {});
     });
 
@@ -100,7 +100,7 @@ describe("Modbus RTU buffered port", function() {
             port.open(function() {
                 port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
-                    for (var i = 0; i < LONG_MSG.length; i += 2) {
+                    for (let i = 0; i < LONG_MSG.length; i += 2) {
                         port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "hex"));
                     }
                 });

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -1,18 +1,18 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
 describe("Modbus TCP port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("./../mocks/netMock");
+        const mock = require("./../mocks/netMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("net", mock);
-        var TcpPort = require("./../../ports/tcpport");
+        const TcpPort = require("./../../ports/tcpport");
         port = new TcpPort("127.0.0.1", { port: 9999 });
     });
 

--- a/test/ports/tcpportrtubuffered.test.js
+++ b/test/ports/tcpportrtubuffered.test.js
@@ -1,11 +1,11 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
 describe("Modbus TCP RTU buffered port", function() {
-    var port;
+    let port;
 
     function send(buffers) {
         port.open(function() {
@@ -17,11 +17,11 @@ describe("Modbus TCP RTU buffered port", function() {
     }
 
     before(function() {
-        var mock = require("./../mocks/netMock");
+        const mock = require("./../mocks/netMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("net", mock);
-        var TcpRTUBufferedPort = require("./../../ports/tcprtubufferedport");
+        const TcpRTUBufferedPort = require("./../../ports/tcprtubufferedport");
         port = new TcpRTUBufferedPort("127.0.0.1", { port: 9999 });
     });
 

--- a/test/ports/telnetport.test.js
+++ b/test/ports/telnetport.test.js
@@ -1,23 +1,23 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
-var LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
+const LONG_MSG = "010380018301830183018301830183018301830183018301830183018301830\
 1830183018301830183018301830183018301830183018301830183018301830183018301830183\
 0183018301830183018301830183018301830183018301830183018301830183018301830183018\
 3018301830183018301830183018301830183018346e0";
 
 describe("Modbus Telnet port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("./../mocks/netMock");
+        const mock = require("./../mocks/netMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("net", mock);
-        var TelnetPort = require("./../../ports/telnetport");
+        const TelnetPort = require("./../../ports/telnetport");
         port = new TelnetPort("127.0.0.1", { port: 9999 });
     });
 
@@ -118,7 +118,7 @@ describe("Modbus Telnet port", function() {
             port.open(function() {
                 port.write(Buffer.from("010300000040443A", "hex"));
                 setTimeout(function() {
-                    for (var i = 0; i < LONG_MSG.length; i += 2) {
+                    for (let i = 0; i < LONG_MSG.length; i += 2) {
                         port._client.receive(Buffer.from(LONG_MSG.slice(i, i + 2), "hex"));
                     }
                 });

--- a/test/ports/udpport.test.js
+++ b/test/ports/udpport.test.js
@@ -1,18 +1,18 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
-var mockery = require("mockery");
+const expect = require("chai").expect;
+const mockery = require("mockery");
 
 describe("Modbus UDP port", function() {
-    var port;
+    let port;
 
     before(function() {
-        var mock = require("../mocks/dgramMock");
+        const mock = require("../mocks/dgramMock");
         mockery.resetCache();
         mockery.enable({ warnOnReplace: false, useCleanCache: true, warnOnUnregistered: false });
         mockery.registerMock("dgram", mock);
-        var UdpPort = require("../../ports/udpport");
+        const UdpPort = require("../../ports/udpport");
         port = new UdpPort("127.0.0.1", { port: 9999 });
     });
 

--- a/test/servers/servertcp.test.js
+++ b/test/servers/servertcp.test.js
@@ -1,15 +1,15 @@
 "use strict";
 /* eslint-disable no-undef, no-console */
 
-var expect = require("chai").expect;
-var net = require("net");
-var TcpServer = require("./../../servers/servertcp");
+const expect = require("chai").expect;
+const net = require("net");
+const TcpServer = require("./../../servers/servertcp");
 
 describe("Modbus TCP Server (no serverID)", function() {
-    var serverTCP; // eslint-disable-line no-unused-vars
+    let serverTCP; // eslint-disable-line no-unused-vars
 
     before(function() {
-        var vector = {
+        const vector = {
             getInputRegister: function(addr) {
                 return addr;
             },
@@ -96,7 +96,7 @@ describe("Modbus TCP Server (no serverID)", function() {
 
     describe("socket connection error", function() {
         it("should receive an error event on socket closed by client", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 client.destroy();
 
                 serverTCP.emit("socketError");
@@ -114,7 +114,7 @@ describe("Modbus TCP Server (no serverID)", function() {
 
     describe("large client request", function() {
         it("should handle a large request without crash successfully (FC1)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
             });
@@ -129,7 +129,7 @@ describe("Modbus TCP Server (no serverID)", function() {
         });
 
         it("should handle a large request without crash successfully (FC3)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
             });
@@ -144,7 +144,7 @@ describe("Modbus TCP Server (no serverID)", function() {
         });
 
         it("should handle a large request without crash successfully (FC4)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
             });
@@ -163,10 +163,10 @@ describe("Modbus TCP Server (no serverID)", function() {
 });
 
 describe("Modbus TCP Server (serverID = requestID)", function() {
-    var serverTCP; // eslint-disable-line no-unused-vars
+    let serverTCP; // eslint-disable-line no-unused-vars
 
     before(function() {
-        var vector = {
+        const vector = {
             setCoil: function(addr, value) {
                 console.log("\tset coil", addr, value);
                 return;
@@ -198,10 +198,10 @@ describe("Modbus TCP Server (serverID = requestID)", function() {
 });
 
 describe("Modbus TCP Server (serverID != requestID)", function() {
-    var serverTCP; // eslint-disable-line no-unused-vars
+    let serverTCP; // eslint-disable-line no-unused-vars
 
     before(function() {
-        var vector = {
+        const vector = {
             setCoil: function(addr, value) {
                 console.log("\tset coil", addr, value);
                 return;
@@ -216,7 +216,7 @@ describe("Modbus TCP Server (serverID != requestID)", function() {
 
     describe("function code handler", function() {
         it("should receive a no Modbus TCP message for wrong unitID", function(done) {
-            var timeout;
+            let timeout;
             this.timeout(1000 + 100);
 
             const client = net.connect({ host: "0.0.0.0", port: 8512 }, function() {

--- a/test/servers/servertcpCallback.test.js
+++ b/test/servers/servertcpCallback.test.js
@@ -1,15 +1,15 @@
 "use strict";
 /* eslint-disable no-undef, no-console */
 
-var expect = require("chai").expect;
-var net = require("net");
-var TcpServer = require("./../../servers/servertcp");
+const expect = require("chai").expect;
+const net = require("net");
+const TcpServer = require("./../../servers/servertcp");
 
 describe("Modbus TCP Server Callback", function() {
-    var serverTCP; // eslint-disable-line no-unused-vars
+    let serverTCP; // eslint-disable-line no-unused-vars
 
     before(function() {
-        var vector = {
+        const vector = {
             getInputRegister: function(addr, unit, callback) {
                 setTimeout(function() {
                     callback(null, addr);
@@ -98,7 +98,7 @@ describe("Modbus TCP Server Callback", function() {
 
     describe("socket connection error", function() {
         it("should receive an error event on socket closed by client", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 client.destroy();
 
                 serverTCP.emit("socketError");
@@ -115,7 +115,7 @@ describe("Modbus TCP Server Callback", function() {
 
     describe("large client request", function() {
         it("should handle a large request without crash successfully (FC1)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
             });
@@ -128,7 +128,7 @@ describe("Modbus TCP Server Callback", function() {
         });
 
         it("should handle a large request without crash successfully (FC3)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
             });
@@ -141,7 +141,7 @@ describe("Modbus TCP Server Callback", function() {
         });
 
         it("should handle a large request without crash successfully (FC4)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8513 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
             });

--- a/test/servers/servertcpPromise.test.js
+++ b/test/servers/servertcpPromise.test.js
@@ -1,15 +1,15 @@
 "use strict";
 /* eslint-disable no-undef, no-console */
 
-var expect = require("chai").expect;
-var net = require("net");
-var TcpServer = require("./../../servers/servertcp");
+const expect = require("chai").expect;
+const net = require("net");
+const TcpServer = require("./../../servers/servertcp");
 
 describe("Modbus TCP Server Promise", function() {
-    var serverTCP; // eslint-disable-line no-unused-vars
+    let serverTCP; // eslint-disable-line no-unused-vars
 
     before(function() {
-        var vector = {
+        const vector = {
             getInputRegister: function(addr) {
                 return new Promise(function(resolve) {
                     setTimeout(function() {
@@ -107,7 +107,7 @@ describe("Modbus TCP Server Promise", function() {
 
     describe("socket connection error", function() {
         it("should receive an error event on socket closed by client", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 client.destroy();
 
                 serverTCP.emit("socketError");
@@ -124,7 +124,7 @@ describe("Modbus TCP Server Promise", function() {
 
     describe("large client request", function() {
         it("should handle a large request without crash successfully (FC1)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060101003EFFFF", "hex"));
             });
@@ -137,7 +137,7 @@ describe("Modbus TCP Server Promise", function() {
         });
 
         it("should handle a large request without crash successfully (FC3)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060103003EFFFF", "hex"));
             });
@@ -150,7 +150,7 @@ describe("Modbus TCP Server Promise", function() {
         });
 
         it("should handle a large request without crash successfully (FC4)", function(done) {
-            var client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
+            const client = net.connect({ host: "0.0.0.0", port: 8514 }, function() {
                 // request 65535 registers at once
                 client.write(Buffer.from("0001000000060104003EFFFF", "hex"));
             });

--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,13 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var ModbusRTU = require("../index");
-var TestPort = ModbusRTU.TestPort;
-var testPort = new TestPort();
-var modbusRTU = new ModbusRTU(testPort);
+const ModbusRTU = require("../index");
+const TestPort = ModbusRTU.TestPort;
+const testPort = new TestPort();
+const modbusRTU = new ModbusRTU(testPort);
 
-var sinon = require("sinon");
-var expect = require("chai").expect;
+const sinon = require("sinon");
+const expect = require("chai").expect;
 
 describe("ModbusRTU", function() {
 
@@ -388,8 +388,8 @@ describe("ModbusRTU", function() {
         });
 
         describe("Timeout", function() {
-            var timeout = 1000;
-            var clock;
+            const timeout = 1000;
+            let clock;
             beforeEach(function() {
                 clock = sinon.useFakeTimers();
             });

--- a/test/utils/crc16.test.js
+++ b/test/utils/crc16.test.js
@@ -1,23 +1,23 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
+const expect = require("chai").expect;
 
-var crc16 = require("../../utils/crc16");
+const crc16 = require("../../utils/crc16");
 
 describe("Modbus CRC16", function() {
 
     describe("crc16() - calculate checksum", function() {
         it("should calculate a valid checksum", function(done) {
-            var buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
-            var crc = crc16(buffer);
+            const buffer = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+            const crc = crc16(buffer);
             expect(crc).to.equal(50227);
             done();
         });
 
         it("should calculate a valid checksum", function(done) {
-            var buffer = Buffer.from("110100130025", "hex");
-            var crc = crc16(buffer);
+            const buffer = Buffer.from("110100130025", "hex");
+            const crc = crc16(buffer);
             expect(crc).to.equal(33806);
             done();
         });

--- a/test/utils/lrc.test.js
+++ b/test/utils/lrc.test.js
@@ -1,16 +1,16 @@
 "use strict";
 /* eslint-disable no-undef */
 
-var expect = require("chai").expect;
+const expect = require("chai").expect;
 
-var calculateLrc = require("./../../utils/lrc");
+const calculateLrc = require("./../../utils/lrc");
 
 describe("Modbus LRC", function() {
 
     describe("lrc() - calculate checksum", function() {
         it("should calculate a valid checksum", function(done) {
-            var buffer = Buffer.from("1103006B0003", "hex");
-            var lrc = calculateLrc(buffer);
+            const buffer = Buffer.from("1103006B0003", "hex");
+            const lrc = calculateLrc(buffer);
             expect(lrc).to.equal(126);
             done();
         });

--- a/utils/buffer_bit.js
+++ b/utils/buffer_bit.js
@@ -18,7 +18,7 @@
 /**
  * Adds Bit Operations to Buffer
  */
-var addBufferBitOp = function() {
+const addBufferBitOp = function() {
 
     /**
      * Add set one bit in a Buffer prototype.
@@ -28,12 +28,12 @@ var addBufferBitOp = function() {
      * @param {number} offset, the byte offset.
      */
     Buffer.prototype.writeBit = function(value, bit, offset) {
-        var byteOffset = parseInt(bit / 8 + offset);
-        var bitOffset = bit % 8;
-        var bitMask = 0x1 << bitOffset;
+        const byteOffset = parseInt(bit / 8 + offset);
+        const bitOffset = bit % 8;
+        const bitMask = 0x1 << bitOffset;
 
         // get byte from buffer
-        var byte = this.readUInt8(byteOffset);
+        let byte = this.readUInt8(byteOffset);
 
         // set bit on / off
         if (value) {
@@ -55,12 +55,12 @@ var addBufferBitOp = function() {
      * @return {boolean} the state of the bit.
      */
     Buffer.prototype.readBit = function(bit, offset) {
-        var byteOffset = parseInt(bit / 8 + offset);
-        var bitOffset = bit % 8;
-        var bitMask = 0x1 << bitOffset;
+        const byteOffset = parseInt(bit / 8 + offset);
+        const bitOffset = bit % 8;
+        const bitMask = 0x1 << bitOffset;
 
         // get byte from buffer
-        var byte = this.readUInt8(byteOffset);
+        const byte = this.readUInt8(byteOffset);
 
         // check bit state
         return (byte & bitMask) === bitMask;

--- a/utils/crc16.js
+++ b/utils/crc16.js
@@ -6,13 +6,13 @@
  * @return {number} the calculated CRC16.
  */
 module.exports = function crc16(buffer) {
-    var crc = 0xFFFF;
-    var odd;
+    let crc = 0xFFFF;
+    let odd;
 
-    for (var i = 0; i < buffer.length; i++) {
+    for (let i = 0; i < buffer.length; i++) {
         crc = crc ^ buffer[i];
 
-        for (var j = 0; j < 8; j++) {
+        for (let j = 0; j < 8; j++) {
             odd = crc & 0x0001;
             crc = crc >> 1;
             if (odd) {

--- a/utils/lrc.js
+++ b/utils/lrc.js
@@ -6,8 +6,8 @@
  * @return {number} the calculated LRC.
  */
 module.exports = function lrc(buffer) {
-    var lrc = 0;
-    for (var i = 0; i < buffer.length; i++) {
+    let lrc = 0;
+    for (let i = 0; i < buffer.length; i++) {
         lrc += buffer[i] & 0xFF;
     }
 


### PR DESCRIPTION
Support for `let` and `const` has existed in Node.js since v6.0.0 and the minimum Node.js version that this package appears to support currently is Node.js v10. In other words, it should be safe to use these new keywords which essentially replace the `var` keyword.

This PR also enables the `no-var` ESLint rule, which prevents `var` usage from now on. The only exception is the `servers/servertcp_handler.js` file, where `var` is currently used in questionable ways which can't directly translate to let/const.