### PR TITLE
Remove removeAllListeners from close callback.

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -166,8 +166,6 @@ class TcpPort extends EventEmitter {
         this.callback = callback;
         // DON'T pass callback to `end()` here, it will be handled by client.on('close') handler
         this._client.end();
-
-        this.removeAllListeners();
     }
 
     /**


### PR DESCRIPTION
In index.js line 523, "modbus._port.once("close", modbus.emit.bind(modbus, "close"));" is not called when we use the close method on line 165.
https://github.com/yaacov/node-modbus-serial/blob/master/index.js#L523

I believe the reason for this is that the method calls client.end() and then removeAllListeners(). What actually should happen is that we should wait until we emit close. Which we do on line 110.
https://github.com/yaacov/node-modbus-serial/blob/master/ports/tcpport.js#L110

So I think this removeAllListeners is redundant and causes undesirable behavior.