### PR TITLE
fix: SocketError -> socketError

### DIFF
--- a/ServerTCP.d.ts
+++ b/ServerTCP.d.ts
@@ -48,7 +48,7 @@ interface IServerOptions {
 }
 
 export declare interface ServerTCP {
-    on(event: 'SocketError', listener: FCallback): this;
+    on(event: 'socketError', listener: FCallback): this;
     on(event: 'error', listener: FCallback): this;
     on(event: 'initialized', listener: FCallback): this;
 }


### PR DESCRIPTION
in the rest of the project `socketError` (starting with a lower case `s`) is used