### PR TITLE
ModbusRTU Slave (Server Serial)

### DIFF
--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,6 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
+const ServerSerialPipeHandler = require("./serverserial_pipe_handler")
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -211,10 +212,18 @@ class ServerSerial extends EventEmitter {
             unitID: options?.unitID ?? 255
         }
 
+        const optionsWithSerialPortTimeoutParser = {
+            maxBufferSize: options?.maxBufferSize ?? 65536,
+            interval: options?.interval ?? 30,
+        }
+
         if (options?.binding) optionsWithBinding.binding = options.binding;
 
         // create a serial server
-        modbus._server = new SerialPort(optionsWithBinding);
+        modbus._serverPath = new SerialPort(optionsWithBinding);
+
+        // create a serial server with a timeout parser
+        modbus._server = new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser);
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,6 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
+const { InterByteTimeoutParser } = require("@serialport/parser-inter-byte-timeout");
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -205,12 +206,14 @@ class ServerSerial extends EventEmitter {
         options = options || {};
 
         // create a serial server
-        modbus._server = new SerialPort({
+        modbus._serverPath = new SerialPort({
             path: options?.path ?? PORT,
             baudRate: options?.baudRate ?? BAUDRATE,
             debug: options?.debug ?? false,
             unitID: options?.unitID ?? 255
         });
+
+        modbus._server = modbus._serverPath.pipe(new InterByteTimeoutParser({ interval:30 }))
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -327,7 +327,7 @@ class ServerSerial extends EventEmitter {
         // close the net port if exist
         if (modbus._server) {
             modbus._server.removeAllListeners("data");
-            modbus._server.close(callback);
+            modbus._serverPath.close(callback);
 
             modbus.socks.forEach(function(e, sock) {
                 sock.destroy();

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -192,7 +192,7 @@ function _parseModbusBuffer(requestBuffer, vector, serverUnitID, sockWriter) {
 
 class ServerSerial extends EventEmitter {
     /**
-     * Class making ModbusTCP server.
+     * Class making ModbusRTU server.
      *
      * @param vector - vector of server functions (see examples/server.js)
      * @param options - server options (host (IP), port, debug (true/false), unitID)
@@ -204,16 +204,13 @@ class ServerSerial extends EventEmitter {
         const modbus = this;
         options = options || {};
 
-        const optionsWithBinding = {
-            path: options.port || PORT,
-            baudRate: options.baudrate || BAUDRATE,
-            debug: options.debug || false,
-            unitID: options.unitID || 255
-        };
-        if (options.binding) optionsWithBinding.binding = options.binding;
-
         // create a serial server
-        modbus._server = new SerialPort(optionsWithBinding);
+        modbus._server = new SerialPort({
+            path: options?.path ?? PORT,
+            baudRate: options?.baudRate ?? BAUDRATE,
+            debug: options?.debug ?? false,
+            unitID: options?.unitID ?? 255
+        });
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -287,7 +287,7 @@ class ServerSerial extends EventEmitter {
                         modbusSerialDebug(JSON.stringify({ action: "send string", data: responseBuffer }));
 
                         // write to port
-                        (options.portResponse || modbus._server).write(responseBuffer);
+                        (options.portResponse || modbus._serverPath).write(responseBuffer);
                     }
                 };
 

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -223,7 +223,7 @@ class ServerSerial extends EventEmitter {
         modbus._serverPath = new SerialPort(optionsWithBinding);
 
         // create a serial server with a timeout parser
-        modbus._server = new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser);
+        modbus._server = modbus._serverPath.pipe(new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser));
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,7 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
-const ServerSerialPipeHandler = require("./serverserial_pipe_handler")
+const ServerSerialPipeHandler = require("./serverserial_pipe_handler");
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -206,18 +206,18 @@ class ServerSerial extends EventEmitter {
         options = options || {};
 
         const optionsWithBinding = {
-            path: options?.path ?? options?.port ?? PORT,
-            baudRate: options?.baudRate ?? options?.baudrate ?? BAUDRATE,
-            debug: options?.debug ?? false,
-            unitID: options?.unitID ?? 255
-        }
+            path: options.path || options.port || PORT,
+            baudRate: options.baudRate || options.baudrate || BAUDRATE,
+            debug: options.debug || false,
+            unitID: options.unitID || 255
+        };
 
         const optionsWithSerialPortTimeoutParser = {
-            maxBufferSize: options?.maxBufferSize ?? 65536,
-            interval: options?.interval ?? 30,
-        }
+            maxBufferSize: options.maxBufferSize || 65536,
+            interval: options.interval || 30
+        };
 
-        if (options?.binding) optionsWithBinding.binding = options.binding;
+        if (options.binding) optionsWithBinding.binding = options.binding;
 
         // create a serial server
         modbus._serverPath = new SerialPort(optionsWithBinding);

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -1,0 +1,57 @@
+const stream = require("stream");
+
+class ServerSerialPipeHandler extends stream.Transform {
+    constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
+        super(transformOptions);
+        if (!interval) {
+            throw new TypeError('"interval" is required');
+        }
+        if (typeof interval !== 'number' || Number.isNaN(interval)) {
+            throw new TypeError('"interval" is not a number');
+        }
+        if (interval < 1) {
+            throw new TypeError('"interval" is not greater than 0');
+        }
+        if (typeof maxBufferSize !== 'number' || Number.isNaN(maxBufferSize)) {
+            throw new TypeError('"maxBufferSize" is not a number');
+        }
+        if (maxBufferSize < 1) {
+            throw new TypeError('"maxBufferSize" is not greater than 0');
+        }
+        this.maxBufferSize = maxBufferSize;
+        this.currentPacket = Buffer.from([]);
+        this.interval = interval;
+    }
+
+    _transform(chunk, encoding, cb) {
+        if (this.intervalID) {
+            clearTimeout(this.intervalID);
+        }
+
+        let offset = 0;
+        while ((this.currentPacket.length + chunk.length) >= this.maxBufferSize) {
+            this.currentPacket = Buffer.concat([this.currentPacket, chunk.slice(offset, this.maxBufferSize - this.currentPacket.length)]);
+            offset = offset + this.maxBufferSize;
+            chunk = chunk.slice(offset);
+            this.emitPacket();
+        }
+        this.currentPacket = Buffer.concat([this.currentPacket, chunk]);
+        this.intervalID = setTimeout(this.emitPacket.bind(this), this.interval);
+        cb();
+    }
+    emitPacket() {
+        if (this.intervalID) {
+            clearTimeout(this.intervalID);
+        }
+        if (this.currentPacket.length > 0) {
+            this.push(this.currentPacket);
+        }
+        this.currentPacket = Buffer.from([]);
+    }
+    _flush(cb) {
+        this.emitPacket();
+        cb();
+    }
+}
+
+module.exports = ServerSerialPipeHandler;

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -4,19 +4,19 @@ class ServerSerialPipeHandler extends stream.Transform {
     constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
         super(transformOptions);
         if (!interval) {
-            throw new TypeError('"interval" is required');
+            throw new TypeError("\"interval\" is required");
         }
-        if (typeof interval !== 'number' || Number.isNaN(interval)) {
-            throw new TypeError('"interval" is not a number');
+        if (typeof interval !== "number" || Number.isNaN(interval)) {
+            throw new TypeError("\"interval\" is not a number");
         }
         if (interval < 1) {
-            throw new TypeError('"interval" is not greater than 0');
+            throw new TypeError("\"interval\" is not greater than 0");
         }
-        if (typeof maxBufferSize !== 'number' || Number.isNaN(maxBufferSize)) {
-            throw new TypeError('"maxBufferSize" is not a number');
+        if (typeof maxBufferSize !== "number" || Number.isNaN(maxBufferSize)) {
+            throw new TypeError("\"maxBufferSize\" is not a number");
         }
         if (maxBufferSize < 1) {
-            throw new TypeError('"maxBufferSize" is not greater than 0');
+            throw new TypeError("\"maxBufferSize\" is not greater than 0");
         }
         this.maxBufferSize = maxBufferSize;
         this.currentPacket = Buffer.from([]);

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -1,7 +1,7 @@
 const stream = require("stream");
 
 class ServerSerialPipeHandler extends stream.Transform {
-    constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
+    constructor({ maxBufferSize = 65536, interval, transformOptions }) {
         super(transformOptions);
         if (!interval) {
             throw new TypeError("\"interval\" is required");


### PR DESCRIPTION
#488 

## ModbusRTU Slave (Server Serial) fix
- a serialport timeout-parser for SerialServer
- create server options interface sync to SerialPort
  ```javascript
   const options = {
       path: "/dev/ttyUSB0",
       baudRate: 9600,
       debug: false,
       unitID: 1
   }
   const RTUSlave = new ModbusRTU.ServerSerial(vector, options);
  ```
- make responseBuffer and Close port use different of  ParserPort (Otherwise it will cause echo, that will looks like blocking)


Because in CI test It cannot reflect the real hardware and the packet receiving and sending status when passing through modbusRTU.
If just use modbusTCP Handler, When serialport encounters a data packet and the receiving time is a little longer, an unparseable situation will occur.
So I wrote with reference to the timeout-parser in SerialPort. The reason for not using serialPort's parser directly is to reduce third-party dependencies.
Allows developers to adjust the delay parameters of receiving packets according to the actual device packet delay

So I add a timeout-parser for SerialServer and I try to get parameter option to sync with SerialPort. 
Avoid misunderstandings in the absence of documents and instructions
but I'm still compatible with the past, like:
```javascript
optionswithbinding = {
path: options.path || oprtions.port || PORT,
}
```

Finally, it was found that calling the correct port of responseBuffer will cause unexpected recursive blocking, so in the two events of responseBuffer and close, the original path is used instead of the path after the parser

## Original description:

- 增加了一個適用於serialport的timeout-parser
- 令modbus.ServerSerial 建構子的options 與 SerialPort建構子的options同步，避免採用與TCP相同的參數導致誤會
- 修正了使用parser時，由於監聽port與寫入的port同樣而導致意外無止盡遞迴(那將會看起來像是阻塞)

由於原先的CI測試中，並沒有考量到物理層面的延遲，因此無法正確地接收Packet解析。
所以我參考了SerialPort中的timeout-parser進行撰寫，不直接使用serialPort的解析器是為了降低第三方依賴。
讓開發者能夠根據實際裝置封包延遲情況，調整接收封包的延遲參數

並嘗試讓modbus.ServerSerial的建構子參數與SerialPort的建構子參數相似，減少參考資料及文件缺失的情況下的誤會。

最後發現responseBuffer調用部正確的port會造成意外的遞迴阻塞，因此responseBuffer以及close這兩個事件中，使用了原始的path而非經過解析器後的path
