### PR TITLE
fix serialport server bug

### DIFF
--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,6 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
+const ServerSerialPipeHandler = require("./serverserial_pipe_handler")
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -211,10 +212,18 @@ class ServerSerial extends EventEmitter {
             unitID: options?.unitID ?? 255
         }
 
+        const optionsWithSerialPortTimeoutParser = {
+            maxBufferSize: options?.maxBufferSize ?? 65536,
+            interval: options?.interval ?? 30,
+        }
+
         if (options?.binding) optionsWithBinding.binding = options.binding;
 
         // create a serial server
-        modbus._server = new SerialPort(optionsWithBinding);
+        modbus._serverPath = new SerialPort(optionsWithBinding);
+
+        // create a serial server with a timeout parser
+        modbus._server = new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser);
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -313,7 +313,7 @@ class ServerSerial extends EventEmitter {
     }
 
     getPort() {
-        return this._server;
+        return this._serverPath;
     }
 
     /**

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,6 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
+const { InterByteTimeoutParser } = require("@serialport/parser-inter-byte-timeout");
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -205,12 +206,14 @@ class ServerSerial extends EventEmitter {
         options = options || {};
 
         // create a serial server
-        modbus._server = new SerialPort({
+        modbus._serverPath = new SerialPort({
             path: options?.path ?? PORT,
             baudRate: options?.baudRate ?? BAUDRATE,
             debug: options?.debug ?? false,
             unitID: options?.unitID ?? 255
         });
+
+        modbus._server = modbus._serverPath.pipe(new InterByteTimeoutParser({ interval:30 }))
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -327,7 +327,7 @@ class ServerSerial extends EventEmitter {
         // close the net port if exist
         if (modbus._server) {
             modbus._server.removeAllListeners("data");
-            modbus._server.close(callback);
+            modbus._serverPath.close(callback);
 
             modbus.socks.forEach(function(e, sock) {
                 sock.destroy();

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -192,7 +192,7 @@ function _parseModbusBuffer(requestBuffer, vector, serverUnitID, sockWriter) {
 
 class ServerSerial extends EventEmitter {
     /**
-     * Class making ModbusTCP server.
+     * Class making ModbusRTU server.
      *
      * @param vector - vector of server functions (see examples/server.js)
      * @param options - server options (host (IP), port, debug (true/false), unitID)
@@ -204,16 +204,13 @@ class ServerSerial extends EventEmitter {
         const modbus = this;
         options = options || {};
 
-        const optionsWithBinding = {
-            path: options.port || PORT,
-            baudRate: options.baudrate || BAUDRATE,
-            debug: options.debug || false,
-            unitID: options.unitID || 255
-        };
-        if (options.binding) optionsWithBinding.binding = options.binding;
-
         // create a serial server
-        modbus._server = new SerialPort(optionsWithBinding);
+        modbus._server = new SerialPort({
+            path: options?.path ?? PORT,
+            baudRate: options?.baudRate ?? BAUDRATE,
+            debug: options?.debug ?? false,
+            unitID: options?.unitID ?? 255
+        });
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -287,7 +287,7 @@ class ServerSerial extends EventEmitter {
                         modbusSerialDebug(JSON.stringify({ action: "send string", data: responseBuffer }));
 
                         // write to port
-                        (options.portResponse || modbus._server).write(responseBuffer);
+                        (options.portResponse || modbus._serverPath).write(responseBuffer);
                     }
                 };
 

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -197,9 +197,10 @@ class ServerSerial extends EventEmitter {
      *
      * @param vector - vector of server functions (see examples/server.js)
      * @param options - server options (host (IP), port, debug (true/false), unitID)
+     * @param serialportOptions - additional parameters for serialport options
      * @constructor
      */
-    constructor(vector, options) {
+    constructor(vector, options, serialportOptions) {
         super();
 
         const modbus = this;
@@ -219,8 +220,11 @@ class ServerSerial extends EventEmitter {
 
         if (options.binding) optionsWithBinding.binding = options.binding;
 
+        // Assign extra parameters in serialport
+        const optionsWithBindinsg = Object.assign({}, serialportOptions, optionsWithBinding);
+
         // create a serial server
-        modbus._serverPath = new SerialPort(optionsWithBinding);
+        modbus._serverPath = new SerialPort(optionsWithBindinsg);
 
         // create a serial server with a timeout parser
         modbus._server = modbus._serverPath.pipe(new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser));

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -223,7 +223,7 @@ class ServerSerial extends EventEmitter {
         modbus._serverPath = new SerialPort(optionsWithBinding);
 
         // create a serial server with a timeout parser
-        modbus._server = new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser);
+        modbus._server = modbus._serverPath.pipe(new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser));
 
         // Open errors will be emitted as an error event
         modbus._server.on("error", function(err) {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -221,10 +221,10 @@ class ServerSerial extends EventEmitter {
         if (options.binding) optionsWithBinding.binding = options.binding;
 
         // Assign extra parameters in serialport
-        const optionsWithBindinsg = Object.assign({}, serialportOptions, optionsWithBinding);
+        const optionsWithBindingandSerialport = Object.assign({}, serialportOptions, optionsWithBinding);
 
         // create a serial server
-        modbus._serverPath = new SerialPort(optionsWithBindinsg);
+        modbus._serverPath = new SerialPort(optionsWithBindingandSerialport);
 
         // create a serial server with a timeout parser
         modbus._server = modbus._serverPath.pipe(new ServerSerialPipeHandler(optionsWithSerialPortTimeoutParser));

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -18,7 +18,7 @@ const events = require("events");
 const EventEmitter = events.EventEmitter || events;
 const modbusSerialDebug = require("debug")("modbus-serial");
 const { SerialPort } = require("serialport");
-const ServerSerialPipeHandler = require("./serverserial_pipe_handler")
+const ServerSerialPipeHandler = require("./serverserial_pipe_handler");
 
 const PORT = "/dev/tty";
 const BAUDRATE = 9600;
@@ -206,18 +206,18 @@ class ServerSerial extends EventEmitter {
         options = options || {};
 
         const optionsWithBinding = {
-            path: options?.path ?? options?.port ?? PORT,
-            baudRate: options?.baudRate ?? options?.baudrate ?? BAUDRATE,
-            debug: options?.debug ?? false,
-            unitID: options?.unitID ?? 255
-        }
+            path: options.path || options.port || PORT,
+            baudRate: options.baudRate || options.baudrate || BAUDRATE,
+            debug: options.debug || false,
+            unitID: options.unitID || 255
+        };
 
         const optionsWithSerialPortTimeoutParser = {
-            maxBufferSize: options?.maxBufferSize ?? 65536,
-            interval: options?.interval ?? 30,
-        }
+            maxBufferSize: options.maxBufferSize || 65536,
+            interval: options.interval || 30
+        };
 
-        if (options?.binding) optionsWithBinding.binding = options.binding;
+        if (options.binding) optionsWithBinding.binding = options.binding;
 
         // create a serial server
         modbus._serverPath = new SerialPort(optionsWithBinding);

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -1,0 +1,57 @@
+const stream = require("stream");
+
+class ServerSerialPipeHandler extends stream.Transform {
+    constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
+        super(transformOptions);
+        if (!interval) {
+            throw new TypeError('"interval" is required');
+        }
+        if (typeof interval !== 'number' || Number.isNaN(interval)) {
+            throw new TypeError('"interval" is not a number');
+        }
+        if (interval < 1) {
+            throw new TypeError('"interval" is not greater than 0');
+        }
+        if (typeof maxBufferSize !== 'number' || Number.isNaN(maxBufferSize)) {
+            throw new TypeError('"maxBufferSize" is not a number');
+        }
+        if (maxBufferSize < 1) {
+            throw new TypeError('"maxBufferSize" is not greater than 0');
+        }
+        this.maxBufferSize = maxBufferSize;
+        this.currentPacket = Buffer.from([]);
+        this.interval = interval;
+    }
+
+    _transform(chunk, encoding, cb) {
+        if (this.intervalID) {
+            clearTimeout(this.intervalID);
+        }
+
+        let offset = 0;
+        while ((this.currentPacket.length + chunk.length) >= this.maxBufferSize) {
+            this.currentPacket = Buffer.concat([this.currentPacket, chunk.slice(offset, this.maxBufferSize - this.currentPacket.length)]);
+            offset = offset + this.maxBufferSize;
+            chunk = chunk.slice(offset);
+            this.emitPacket();
+        }
+        this.currentPacket = Buffer.concat([this.currentPacket, chunk]);
+        this.intervalID = setTimeout(this.emitPacket.bind(this), this.interval);
+        cb();
+    }
+    emitPacket() {
+        if (this.intervalID) {
+            clearTimeout(this.intervalID);
+        }
+        if (this.currentPacket.length > 0) {
+            this.push(this.currentPacket);
+        }
+        this.currentPacket = Buffer.from([]);
+    }
+    _flush(cb) {
+        this.emitPacket();
+        cb();
+    }
+}
+
+module.exports = ServerSerialPipeHandler;

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -4,19 +4,19 @@ class ServerSerialPipeHandler extends stream.Transform {
     constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
         super(transformOptions);
         if (!interval) {
-            throw new TypeError('"interval" is required');
+            throw new TypeError("\"interval\" is required");
         }
-        if (typeof interval !== 'number' || Number.isNaN(interval)) {
-            throw new TypeError('"interval" is not a number');
+        if (typeof interval !== "number" || Number.isNaN(interval)) {
+            throw new TypeError("\"interval\" is not a number");
         }
         if (interval < 1) {
-            throw new TypeError('"interval" is not greater than 0');
+            throw new TypeError("\"interval\" is not greater than 0");
         }
-        if (typeof maxBufferSize !== 'number' || Number.isNaN(maxBufferSize)) {
-            throw new TypeError('"maxBufferSize" is not a number');
+        if (typeof maxBufferSize !== "number" || Number.isNaN(maxBufferSize)) {
+            throw new TypeError("\"maxBufferSize\" is not a number");
         }
         if (maxBufferSize < 1) {
-            throw new TypeError('"maxBufferSize" is not greater than 0');
+            throw new TypeError("\"maxBufferSize\" is not greater than 0");
         }
         this.maxBufferSize = maxBufferSize;
         this.currentPacket = Buffer.from([]);

--- a/servers/serverserial_pipe_handler.js
+++ b/servers/serverserial_pipe_handler.js
@@ -1,7 +1,7 @@
 const stream = require("stream");
 
 class ServerSerialPipeHandler extends stream.Transform {
-    constructor ({ maxBufferSize = 65536, interval, ...transformOptions }) {
+    constructor({ maxBufferSize = 65536, interval, transformOptions }) {
         super(transformOptions);
         if (!interval) {
             throw new TypeError("\"interval\" is required");


### PR DESCRIPTION
- getPort method will return Serialport instance not parser instance
- when create serialport, pass serialport parameter to serialport constructor, not just ignore. Contributes to developer flexibility when using the suite