### PR TITLE
Add `getPorts` method

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -1,8 +1,12 @@
 import { Socket } from 'net';
 import { TestPort } from "./TestPort";
+import { PortInfo } from '@serialport/bindings-cpp';
+
 export class ModbusRTU {
   constructor(port?: any);
   static TestPort: typeof TestPort
+
+  static getPorts(): Promise<PortInfo[]>
 
   open(callback: Function): void;
   close(callback: Function): void;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@
 /* Add bit operation functions to Buffer
  */
 require("./utils/buffer_bit")();
+const { SerialPort } = require("serialport");
 const crc16 = require("./utils/crc16");
 const modbusSerialDebug = require("debug")("modbus-serial");
 
@@ -1157,6 +1158,11 @@ require("./apis/worker")(ModbusRTU);
 
 // exports
 module.exports = ModbusRTU;
+
+module.exports.getPorts = function getPorts() {
+    return SerialPort.list();
+};
+
 module.exports.TestPort = require("./ports/testport");
 try {
     module.exports.RTUBufferedPort = require("./ports/rtubufferedport");


### PR DESCRIPTION
Most projects using this module will also have to install serialport in order to only list ports, this could lead having multiple serialport versions installed with some issues expecially when cross compiling. With this util method we expose `Serialport.list` to prevent this