### PR TITLE
Bump serialport package version to ^11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "serialport": "^10.4.0"
+    "serialport": "^11.0.0"
   }
 }


### PR DESCRIPTION
There is an upstream error with a certain binary release of the serialport package. It was caused by a maintainer updating libc and this broke cross-compilation on ARM targets and hence a faulty release binary was circulated into the wild. (It was fixed here: [fix: update build tools and fix arm64 build for rpi by reconbot · Pull Request #111 · serialport/bindings-cpp](https://github.com/serialport/bindings-cpp/pull/111)).

Some additional reports are here: 
[node-red-node-serialport node makes the Docker container infinite boot cycle · Issue #894 · node-red/node-red-nodes](https://github.com/node-red/node-red-nodes/issues/894) 

[serialport@10.3.0 fails in docker container on rpi · Issue #2438 · serialport/node-serialport](https://github.com/serialport/node-serialport/issues/2438) 


[Node-RED (Docker) crashes when /dev/ttyACM0 is configured in flow - Raspberry Pi 4 · Issue #3461 · node-red/node-red](https://github.com/node-red/node-red/issues/3461)

The issue is fixed in version 11.0.0