### PR TITLE
Allow to pass socket options to TCP client

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
         "es6": true
     },
     "parserOptions": {
-        "ecmaVersion": 2017
+        "ecmaVersion": 2020
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: 
+on:
   push:
     branches:
       - master
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,3 @@ modbus-serial
 docs
 
 package-lock\.json
-
-# Visual Studio Code
-# .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
@@ -35,4 +36,4 @@ docs
 package-lock\.json
 
 # Visual Studio Code
-.vscode/
+# .vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Current File",
+        "type": "node",
+        "request": "launch",
+        "program": "${file}"
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Mocha single test",
+        "program": "${workspaceFolder}/node_modules/mocha/bin/mocha.js",
+        // current file
+        "args": ["${file}"],
+        "console": "internalConsole",
+        "cwd": "${workspaceRoot}",
+        "runtimeVersion": "16",
+      }
+    ]
+  }
+  

--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -1,4 +1,4 @@
-import { Socket } from 'net';
+import { Socket, SocketConstructorOpts, TcpSocketConnectOpts } from 'net';
 import { TestPort } from "./TestPort";
 import { PortInfo } from '@serialport/bindings-cpp';
 
@@ -133,12 +133,14 @@ export interface SerialPortUnixPlatformOptions {
   vtime?: number;
 }
 
-export interface TcpPortOptions {
+export interface TcpPortOptions extends TcpSocketConnectOpts {
   port?: number;
   localAddress?: string;
   family?: number;
   ip?: string;
   timeout?: number;
+  socket: Socket;
+  socketOpts: SocketConstructorOpts
 }
 
 export interface UdpPortOptions {

--- a/examples/tcp_client_abort_signal.js
+++ b/examples/tcp_client_abort_signal.js
@@ -1,0 +1,58 @@
+"use strict";
+
+// create an empty modbus client
+//let ModbusRTU = require("modbus-serial");
+const ModbusRTU = require("../index");
+const client = new ModbusRTU();
+
+const abortController = new AbortController();
+const { signal } = abortController;
+signal.addEventListener("abort", () => {
+  console.log("Abort signal received by the abort controller");
+});
+
+async function connect() {
+  await client.connectTCP("127.0.0.1", {
+    port: 8502,
+    socketOpts: {
+      signal: signal,
+    },
+  });
+  client.setID(1);
+  client.setTimeout(2000);
+}
+
+async function readRegisters() {
+  const data = await client.readHoldingRegisters(5, 4);
+  console.log("Received:", data.data);
+}
+
+async function runner() {
+  await connect();
+
+  setTimeout(() => {
+    abortController.abort("Aborting request");
+  }, 1000);
+
+  await readRegisters();
+}
+
+runner()
+  .then(() => {
+    if (signal.aborted) {
+      if (signal.reason) {
+        console.log(`Request aborted with reason: ${signal.reason}`);
+      } else {
+        console.log("Request aborted but no reason was given.");
+      }
+    } else {
+      console.log("Request not aborted");
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+  })
+  .finally(async () => {
+    console.log("Close client");
+    await client.close();
+  });

--- a/examples/tcp_client_abort_signal.js
+++ b/examples/tcp_client_abort_signal.js
@@ -1,58 +1,58 @@
 "use strict";
 
 // create an empty modbus client
-//let ModbusRTU = require("modbus-serial");
+// let ModbusRTU = require("modbus-serial");
 const ModbusRTU = require("../index");
 const client = new ModbusRTU();
 
 const abortController = new AbortController();
 const { signal } = abortController;
 signal.addEventListener("abort", () => {
-  console.log("Abort signal received by the abort controller");
+    console.log("Abort signal received by the abort controller");
 });
 
 async function connect() {
-  await client.connectTCP("127.0.0.1", {
-    port: 8502,
-    socketOpts: {
-      signal: signal,
-    },
-  });
-  client.setID(1);
-  client.setTimeout(2000);
+    await client.connectTCP("127.0.0.1", {
+        port: 8502,
+        socketOpts: {
+            signal: signal
+        }
+    });
+    client.setID(1);
+    client.setTimeout(2000);
 }
 
 async function readRegisters() {
-  const data = await client.readHoldingRegisters(5, 4);
-  console.log("Received:", data.data);
+    const data = await client.readHoldingRegisters(5, 4);
+    console.log("Received:", data.data);
 }
 
 async function runner() {
-  await connect();
+    await connect();
 
-  setTimeout(() => {
-    abortController.abort("Aborting request");
-  }, 1000);
+    setTimeout(() => {
+        abortController.abort("Aborting request");
+    }, 1000);
 
-  await readRegisters();
+    await readRegisters();
 }
 
 runner()
-  .then(() => {
-    if (signal.aborted) {
-      if (signal.reason) {
-        console.log(`Request aborted with reason: ${signal.reason}`);
-      } else {
-        console.log("Request aborted but no reason was given.");
-      }
-    } else {
-      console.log("Request not aborted");
-    }
-  })
-  .catch((error) => {
-    console.error(error);
-  })
-  .finally(async () => {
-    console.log("Close client");
-    await client.close();
-  });
+    .then(() => {
+        if (signal.aborted) {
+            if (signal.reason) {
+                console.log(`Request aborted with reason: ${signal.reason}`);
+            } else {
+                console.log("Request aborted but no reason was given.");
+            }
+        } else {
+            console.log("Request not aborted");
+        }
+    })
+    .catch((error) => {
+        console.error(error);
+    })
+    .finally(async() => {
+        console.log("Close client");
+        await client.close();
+    });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "nyc --reporter=lcov --reporter=text mocha --recursive"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "mocha": "^10.2.0",
     "mocha-eslint": "^7.0.0",
     "mockery": "^2.1.0",
+    "nyc": "^15.1.0",
     "pump": "^3.0.0",
     "sinon": "^15.2.0",
     "web-bluetooth-mock": "^1.2.0",

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -18,17 +18,22 @@ class TcpPort extends EventEmitter {
      * Simulate a modbus-RTU port using modbus-TCP connection.
      *
      * @param {string} ip - IP address of Modbus slave.
-     * @param {Object} options - Options object.
-     * @param {number} [options.port=502] - Nonstandard Modbus port (default is 502).
-     * @param {string} options.localAddress -  Local IP address to bind to, default is any.
-     * @param {0|4|6}  [options.family=0] - `4` = IPv4-only, `6` = IPv6-only, `0` = either (default).
-     * @param {number} [options.timeout=5000] - Connection timeout in ms (default is 5000).
-     * @param {net.Socket} [options.socket] - Use existing socket object and ignore all other parameters (ip, port, etc).
+     * @param {{
+     *  port?: number,
+     *  localAddress?: string,
+     *  family?: 0|4|6,
+     *  timeout?: number,
+     *  socket?: net.Socket
+     * } & net.TcpSocketConnectOpts} options - Options object.
+     *   options.port: Nonstandard Modbus port (default is 502).
+     *   options.localAddress: Local IP address to bind to, default is any.
+     *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
      * @constructor
      */
     constructor(ip, options) {
         super();
-        const modbus = this;
+        const self = this;
+        /** @type {boolean} Flag to indicate if port is open */
         this.openFlag = false;
         /** @type {(err?: Error) => void} */
         this.callback = null;
@@ -38,16 +43,20 @@ class TcpPort extends EventEmitter {
 
         if(typeof ip === "object") {
             options = ip;
+            ip = undefined;
         }
 
         if (typeof options === "undefined") options = {};
 
         /** @type {net.TcpSocketConnectOpts} - Options for net.connect(). */
         this.connectOptions =  {
-            host: ip || options.ip,
-            port: options.port || MODBUS_PORT,
-            localAddress: options.localAddress,
-            family: options.family
+            // Default options
+            ...{
+                host: ip || options.ip,
+                port: MODBUS_PORT,
+            },
+            // User options
+            ...options,
         };
 
         if(options.socket) {
@@ -62,9 +71,9 @@ class TcpPort extends EventEmitter {
         // handle callback - call a callback function only once, for the first event
         // it will trigger
         const handleCallback = function(had_error) {
-            if (modbus.callback) {
-                modbus.callback(had_error);
-                modbus.callback = null;
+            if (self.callback) {
+                self.callback(had_error);
+                self.callback = null;
             }
         };
 
@@ -72,7 +81,10 @@ class TcpPort extends EventEmitter {
         this._client = this._externalSocket || new net.Socket();
 
         if (options.timeout) this._client.setTimeout(options.timeout);
+        
+        // register events handlers
         this._client.on("data", function(data) {
+            console.log("TCP port: signal data");
             let buffer;
             let crc;
             let length;
@@ -94,11 +106,11 @@ class TcpPort extends EventEmitter {
                 buffer.writeUInt16LE(crc, buffer.length - CRC_LENGTH);
 
                 // update transaction id and emit data
-                modbus._transactionIdRead = data.readUInt16BE(0);
-                modbus.emit("data", buffer);
+                self._transactionIdRead = data.readUInt16BE(0);
+                self.emit("data", buffer);
 
                 // debug
-                modbusSerialDebug({ action: "parsed tcp port", buffer: buffer, transactionId: modbus._transactionIdRead });
+                modbusSerialDebug({ action: "parsed tcp port", buffer: buffer, transactionId: self._transactionIdRead });
 
                 // reset data
                 data = data.slice(length + MIN_MBAP_LENGTH);
@@ -106,33 +118,54 @@ class TcpPort extends EventEmitter {
         });
 
         this._client.on("connect", function() {
-            modbus.openFlag = true;
+            console.log("TCP port: signal connect");
+            self.openFlag = true;
             modbusSerialDebug("TCP port: signal connect");
             handleCallback();
         });
 
         this._client.on("close", function(had_error) {
-            modbus.openFlag = false;
+            console.log("TCP port: signal close");
+            self.openFlag = false;
             modbusSerialDebug("TCP port: signal close: " + had_error);
             handleCallback(had_error);
 
-            modbus.emit("close");
-            modbus.removeAllListeners();
+            self.emit("close");
+            self.removeAllListeners();
         });
 
         this._client.on("error", function(had_error) {
-            modbus.openFlag = false;
+            console.log("TCP port: signal error");
+            self.openFlag = false;
             modbusSerialDebug("TCP port: signal error: " + had_error);
             handleCallback(had_error);
         });
 
         this._client.on("timeout", function() {
+            console.log("TCP port: signal timeout");
             // modbus.openFlag is left in its current state as it reflects two types of timeouts,
             // i.e. 'false' for "TCP connection timeout" and 'true' for "Modbus response timeout"
             // (this allows to continue Modbus request re-tries without reconnecting TCP).
             modbusSerialDebug("TCP port: TimedOut");
             handleCallback(new Error("TCP Connection Timed Out"));
         });
+
+        this._client.on("end", function() {
+            console.log("TCP port: signal end");
+        });
+
+        this._client.on("drain", function() {
+            console.log("TCP port: signal drain");
+        });
+
+        this._client.on("lookup", function() {
+            console.log("TCP port: signal lookup");
+        });
+
+        this._client.on("ready", function() {
+            console.log("TCP port: signal ready");
+        });
+
     }
 
     /**

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -17,28 +17,33 @@ class TcpPort extends EventEmitter {
     /**
      * Simulate a modbus-RTU port using modbus-TCP connection.
      *
-     * @param ip
-     * @param options
-     *   options.port: Nonstandard Modbus port (default is 502).
-     *   options.localAddress: Local IP address to bind to, default is any.
-     *   options.family: 4 = IPv4-only, 6 = IPv6-only, 0 = either (default).
+     * @param {string} ip - IP address of Modbus slave.
+     * @param {Object} options - Options object.
+     * @param {number} [options.port=502] - Nonstandard Modbus port (default is 502).
+     * @param {string} options.localAddress -  Local IP address to bind to, default is any.
+     * @param {0|4|6}  [options.family=0] - `4` = IPv4-only, `6` = IPv6-only, `0` = either (default).
+     * @param {number} [options.timeout=5000] - Connection timeout in ms (default is 5000).
+     * @param {net.Socket} [options.socket] - Use existing socket object and ignore all other parameters (ip, port, etc).
      * @constructor
      */
     constructor(ip, options) {
         super();
         const modbus = this;
         this.openFlag = false;
+        /** @type {(err?: Error) => void} */
         this.callback = null;
         this._transactionIdWrite = 1;
+        /** @type {net.Socket?} - Optional custom socket */
         this._externalSocket = null;
 
         if(typeof ip === "object") {
             options = ip;
         }
 
-        if (typeof(options) === "undefined") options = {};
+        if (typeof options === "undefined") options = {};
 
-        this.connectOptions = {
+        /** @type {net.TcpSocketConnectOpts} - Options for net.connect(). */
+        this.connectOptions =  {
             host: ip || options.ip,
             port: options.port || MODBUS_PORT,
             localAddress: options.localAddress,
@@ -55,7 +60,7 @@ class TcpPort extends EventEmitter {
         }
 
         // handle callback - call a callback function only once, for the first event
-        // it will triger
+        // it will trigger
         const handleCallback = function(had_error) {
             if (modbus.callback) {
                 modbus.callback(had_error);
@@ -142,7 +147,7 @@ class TcpPort extends EventEmitter {
     /**
      * Simulate successful port open.
      *
-     * @param callback
+     * @param {(err?: Error) => void} callback
      */
     open(callback) {
         if(this._externalSocket === null) {
@@ -159,7 +164,7 @@ class TcpPort extends EventEmitter {
     /**
      * Simulate successful close port.
      *
-     * @param callback
+     * @param {(err?: Error) => void} callback
      */
     close(callback) {
         this.callback = callback;
@@ -170,7 +175,7 @@ class TcpPort extends EventEmitter {
     /**
      * Simulate successful destroy port.
      *
-     * @param callback
+     * @param {(err?: Error) => void} callback
      */
     destroy(callback) {
         this.callback = callback;
@@ -182,7 +187,7 @@ class TcpPort extends EventEmitter {
     /**
      * Send data to a modbus-tcp slave.
      *
-     * @param data
+     * @param {Buffer} data
      */
     write(data) {
         if(data.length < MIN_DATA_LENGTH) {

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -66,10 +66,10 @@ class TcpPort extends EventEmitter {
             // Default options
             ...{
                 host: ip || options.ip,
-                port: MODBUS_PORT,
+                port: MODBUS_PORT
             },
             // User options
-            ...options,
+            ...options
         };
 
         if(options.socket) {
@@ -94,7 +94,7 @@ class TcpPort extends EventEmitter {
         this._client = this._externalSocket || new net.Socket(this.socketOpts);
 
         if (options.timeout) this._client.setTimeout(options.timeout);
-        
+
         // register events handlers
         this._client.on("data", function(data) {
             let buffer;

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -30,7 +30,7 @@ class TcpPort extends EventEmitter {
      *      readable?: boolean,
      *      writable?: boolean,
      *      signal?: AbortSignal
-     * },
+     *  },
      * } & net.TcpSocketConnectOpts} options - Options object.
      *   options.port: Nonstandard Modbus port (default is 502).
      *   options.localAddress: Local IP address to bind to, default is any.

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -28,45 +28,46 @@ describe("Modbus TCP port methods", function() {
         const TcpPort = require("./../../ports/tcpport");
         it("with ip as string", function() {
             const port = new TcpPort("localhost");
-    
+
             expect(port).to.be.an.instanceOf(TcpPort);
             expect(port.connectOptions.host).to.equal("localhost");
             expect(port.connectOptions.port).to.equal(502);
         });
-    
+
         it("with ip as object", function() {
-            const port = new TcpPort({ip: "localhost"});
-            
+            const port = new TcpPort({ ip: "localhost" });
+
             expect(port).to.be.an.instanceOf(TcpPort);
             expect(port.connectOptions.host).to.equal("localhost");
             expect(port.connectOptions.port).to.equal(502);
         });
-    
+
         it("with ip as object and port as number", function() {
-            const port = new TcpPort({ip: "localhost", port: 9999});
-    
+            const port = new TcpPort({ ip: "localhost", port: 9999 });
+
             expect(port).to.be.an.instanceOf(TcpPort);
             expect(port.connectOptions.host).to.equal("localhost");
             expect(port.connectOptions.port).to.equal(9999);
         });
-    
+
         it("with ip as string and options as object", function() {
             const port = new TcpPort("localhost", { port: 9999 });
-    
+
             expect(port).to.be.an.instanceOf(TcpPort);
             expect(port.connectOptions.host).to.equal("localhost");
             expect(port.connectOptions.port).to.equal(9999);
         });
-    
+
         it("with socket creation options", function() {
             const controller = new AbortController();
-            const port = new TcpPort("localhost", { port: 9999, socketOpts: {
-                allowHalfOpen: true,
-                readable: true,
-                writable: true,
-                signal: controller.signal,
-            }});
-            
+            const port = new TcpPort("localhost", { port: 9999,
+                socketOpts: {
+                    allowHalfOpen: true,
+                    readable: true,
+                    writable: true,
+                    signal: controller.signal
+                } });
+
             expect(port).to.be.an.instanceOf(TcpPort);
             expect(port.connectOptions.host).to.equal("localhost");
             expect(port.connectOptions.port).to.equal(9999);
@@ -74,8 +75,8 @@ describe("Modbus TCP port methods", function() {
                 allowHalfOpen: true,
                 readable: true,
                 writable: true,
-                signal: controller.signal,
-            }); 
+                signal: controller.signal
+            });
         });
     });
 

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -4,7 +4,42 @@
 const expect = require("chai").expect;
 const mockery = require("mockery");
 
-describe("Modbus TCP port", function() {
+describe("Modbus TCP port constructor", function() {
+    const TcpPort = require("./../../ports/tcpport");
+    it("with ip as string", function() {
+        const port = new TcpPort("localhost");
+
+        expect(port).to.be.an.instanceOf(TcpPort);
+        expect(port.connectOptions.host).to.equal("localhost");
+        expect(port.connectOptions.port).to.equal(502);
+    });
+
+    it("with ip as object", function() {
+        const port = new TcpPort({ip: "localhost"});
+        
+        expect(port).to.be.an.instanceOf(TcpPort);
+        expect(port.connectOptions.host).to.equal("localhost");
+        expect(port.connectOptions.port).to.equal(502);
+    });
+
+    it("with ip as object and port as number", function() {
+        const port = new TcpPort({ip: "localhost", port: 9999});
+
+        expect(port).to.be.an.instanceOf(TcpPort);
+        expect(port.connectOptions.host).to.equal("localhost");
+        expect(port.connectOptions.port).to.equal(9999);
+    });
+
+    it("with ip as string and options as object", function() {
+        const port = new TcpPort("localhost", { port: 9999 });
+
+        expect(port).to.be.an.instanceOf(TcpPort);
+        expect(port.connectOptions.host).to.equal("localhost");
+        expect(port.connectOptions.port).to.equal(9999);
+    });
+});
+
+describe("Modbus TCP port methods", function() {
     let port;
 
     before(function() {

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -4,41 +4,6 @@
 const expect = require("chai").expect;
 const mockery = require("mockery");
 
-describe("Modbus TCP port constructor", function() {
-    const TcpPort = require("./../../ports/tcpport");
-    it("with ip as string", function() {
-        const port = new TcpPort("localhost");
-
-        expect(port).to.be.an.instanceOf(TcpPort);
-        expect(port.connectOptions.host).to.equal("localhost");
-        expect(port.connectOptions.port).to.equal(502);
-    });
-
-    it("with ip as object", function() {
-        const port = new TcpPort({ip: "localhost"});
-        
-        expect(port).to.be.an.instanceOf(TcpPort);
-        expect(port.connectOptions.host).to.equal("localhost");
-        expect(port.connectOptions.port).to.equal(502);
-    });
-
-    it("with ip as object and port as number", function() {
-        const port = new TcpPort({ip: "localhost", port: 9999});
-
-        expect(port).to.be.an.instanceOf(TcpPort);
-        expect(port.connectOptions.host).to.equal("localhost");
-        expect(port.connectOptions.port).to.equal(9999);
-    });
-
-    it("with ip as string and options as object", function() {
-        const port = new TcpPort("localhost", { port: 9999 });
-
-        expect(port).to.be.an.instanceOf(TcpPort);
-        expect(port.connectOptions.host).to.equal("localhost");
-        expect(port.connectOptions.port).to.equal(9999);
-    });
-});
-
 describe("Modbus TCP port methods", function() {
     let port;
 
@@ -57,6 +22,61 @@ describe("Modbus TCP port methods", function() {
 
     afterEach(function() {
         port.close();
+    });
+
+    describe("Modbus TCP port constructor", function() {
+        const TcpPort = require("./../../ports/tcpport");
+        it("with ip as string", function() {
+            const port = new TcpPort("localhost");
+    
+            expect(port).to.be.an.instanceOf(TcpPort);
+            expect(port.connectOptions.host).to.equal("localhost");
+            expect(port.connectOptions.port).to.equal(502);
+        });
+    
+        it("with ip as object", function() {
+            const port = new TcpPort({ip: "localhost"});
+            
+            expect(port).to.be.an.instanceOf(TcpPort);
+            expect(port.connectOptions.host).to.equal("localhost");
+            expect(port.connectOptions.port).to.equal(502);
+        });
+    
+        it("with ip as object and port as number", function() {
+            const port = new TcpPort({ip: "localhost", port: 9999});
+    
+            expect(port).to.be.an.instanceOf(TcpPort);
+            expect(port.connectOptions.host).to.equal("localhost");
+            expect(port.connectOptions.port).to.equal(9999);
+        });
+    
+        it("with ip as string and options as object", function() {
+            const port = new TcpPort("localhost", { port: 9999 });
+    
+            expect(port).to.be.an.instanceOf(TcpPort);
+            expect(port.connectOptions.host).to.equal("localhost");
+            expect(port.connectOptions.port).to.equal(9999);
+        });
+    
+        it("with socket creation options", function() {
+            const controller = new AbortController();
+            const port = new TcpPort("localhost", { port: 9999, socketOpts: {
+                allowHalfOpen: true,
+                readable: true,
+                writable: true,
+                signal: controller.signal,
+            }});
+            
+            expect(port).to.be.an.instanceOf(TcpPort);
+            expect(port.connectOptions.host).to.equal("localhost");
+            expect(port.connectOptions.port).to.equal(9999);
+            expect(port.socketOpts).to.deep.equal({
+                allowHalfOpen: true,
+                readable: true,
+                writable: true,
+                signal: controller.signal,
+            }); 
+        });
     });
 
     describe("#isOpen", function() {


### PR DESCRIPTION
Hi @yaacov thank you for the lib. It's been super useful

While doing some debugging I've made some changes to the lib and decided to create a PR.

Here are the changes:
1) allows to pass socket opts (link to docs: https://nodejs.org/api/net.html#new-netsocketoptions)  to the TCP client. When creating `new Socket()`
2) allows to pass TCP connections (link to docs: https://nodejs.org/api/net.html#socketconnectoptions-connectlistener) when calling `_client.connect()`
3) adds a test coverage reporter that helps to see uncovered codebase
![image](https://github.com/yaacov/node-modbus-serial/assets/9802754/71ee0515-3f84-4554-8444-e2ad0fa82c43)
4) adds a vscode launch.json that allows to attach a debugger to unit tests and to the examples in `examples` dir
5) adds and example showing how to use 1) to pass abort signal to the Socket() and easily close the socket.

Re 5) I have a question for you. When the socket emits an error and socket connection is closed, does it make sense to wait for a response (which won't come as socket is closed) and then throw a `TransactionTimedOutError` ?
![image](https://github.com/yaacov/node-modbus-serial/assets/9802754/cf805210-16b2-448e-87fc-275975aaf840)

