### PR TITLE
issues/522 - fix minimum buffer length check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus-serial",
-  "version": "8.0.13",
+  "version": "8.0.14",
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbus-serial",
-  "version": "8.0.14",
+  "version": "8.0.13",
   "description": "A pure JavaScript implemetation of MODBUS-RTU (Serial and TCP) for NodeJS.",
   "main": "index.js",
   "scripts": {

--- a/servers/serverserial.js
+++ b/servers/serverserial.js
@@ -26,6 +26,7 @@ const BAUDRATE = 9600;
 const UNIT_ID = 255; // listen to all adresses
 
 const ADDR_LEN = 1;
+const MIN_LEN = 6;
 
 /* Get Handlers
  */
@@ -124,7 +125,7 @@ function _callbackFactory(unitID, functionCode, sockWriter) {
  */
 function _parseModbusBuffer(requestBuffer, vector, serverUnitID, sockWriter, options) {
     // Check requestBuffer length
-    if (!requestBuffer || requestBuffer.length < ADDR_LEN) {
+    if (!requestBuffer || requestBuffer.length < MIN_LEN) {
         modbusSerialDebug("wrong size of request Buffer " + requestBuffer.length);
         return;
     }

--- a/test/Lint/test.js
+++ b/test/Lint/test.js
@@ -16,7 +16,7 @@ const paths = [
 const options = {
     // Specify style of output
     formatter: "compact", // Defaults to `stylish`
-    timeout: 5000
+    timeout: 10000
 };
 
 // Run the tests

--- a/test/servers/serverserial.test.js
+++ b/test/servers/serverserial.test.js
@@ -229,6 +229,16 @@ describe("Modbus Serial Server (no serverID)", function() {
 
         // TODO: exceptions
     });
+
+    describe("too short client request", function() {
+        it("should handle a request that is too short without crash", function(done) {
+            // valid ID, function code & CRC, but too short body
+            serverSerial.getPort().write(Buffer.from("081013bc0f", "hex"));
+
+            // wait a bit to make sure we didn't crash
+            setTimeout(done, 50);
+        });
+    });
 });
 
 describe("Modbus Serial Server (serverID = requestID)", function() {


### PR DESCRIPTION
Check that request buffer is at least 6 bytes long to allow proper extraction of payload length.