### PR TITLE
Align TcpPortOptions with TcpSocketConnectOpts

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -134,13 +134,13 @@ export interface SerialPortUnixPlatformOptions {
 }
 
 export interface TcpPortOptions extends TcpSocketConnectOpts {
-  port?: number;
+  port: number;
   localAddress?: string;
   family?: number;
   ip?: string;
   timeout?: number;
   socket: Socket;
-  socketOpts: SocketConstructorOpts
+  socketOpts: SocketConstructorOpts;
 }
 
 export interface UdpPortOptions {


### PR DESCRIPTION
Fixes: https://github.com/yaacov/node-modbus-serial/issues/524

Issue:
a. `TcpSocketConnectOpts` requires `port`  if we inherit  `TcpPortOptions` from it, we should also make port required.
b. missing `;`  at line 143