### PR TITLE
Make socket and socketopts optional

### DIFF
--- a/ModbusRTU.d.ts
+++ b/ModbusRTU.d.ts
@@ -139,8 +139,8 @@ export interface TcpPortOptions extends TcpSocketConnectOpts {
   family?: number;
   ip?: string;
   timeout?: number;
-  socket: Socket;
-  socketOpts: SocketConstructorOpts;
+  socket?: Socket;
+  socketOpts?: SocketConstructorOpts;
 }
 
 export interface UdpPortOptions {


### PR DESCRIPTION
Fix: https://github.com/yaacov/node-modbus-serial/issues/530

Issue: socket and socketOpts should be optional
