### PR TITLE
fix: ServerTCP causes uncaught exception if listen fails

### DIFF
--- a/ServerTCP.d.ts
+++ b/ServerTCP.d.ts
@@ -53,6 +53,7 @@ interface IServerOptions {
 
 export declare interface ServerTCP {
     on(event: 'socketError', listener: FCallback): this;
+    on(event: 'serverError', listener: FCallback): this;
     on(event: 'error', listener: FCallback): this;
     on(event: 'initialized', listener: FCallback): this;
 }

--- a/servers/servertcp.js
+++ b/servers/servertcp.js
@@ -217,6 +217,9 @@ class ServerTCP extends EventEmitter {
 
         // create a tcp server
         modbus._server = net.createServer();
+        modbus._server.on("error", function(error) {
+            modbus.emit("serverError", error);
+        });
         modbus._server.listen({
             port: options.port || MODBUS_PORT,
             host: options.host || HOST


### PR DESCRIPTION
fixes https://github.com/yaacov/node-modbus-serial/issues/536

I've opted for a separate event (`serverError`), as `error` is already used and the with the two kinds will probably have to be dealt with differently.