### PR TITLE
fix: catch error thrown in getMultipleHoldingRegisters

### DIFF
--- a/servers/servertcp_handler.js
+++ b/servers/servertcp_handler.js
@@ -296,7 +296,13 @@ function _handleReadMultipleRegisters(requestBuffer, vector, unitID, callback) {
                 }
             });
         } else {
-            const values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            let values;
+            try {
+                values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            } catch (error) {
+                callback(error);
+                return;
+            }
             if (values.length === length) {
                 for (i = 0; i < length; i++) {
                     tryAndHandlePromiseOrValue(i, values);
@@ -434,7 +440,13 @@ function _handleReadMultipleRegistersEnron(requestBuffer, vector, unitID, enronT
                 }
             });
         } else {
-            const values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            let values;
+            try {
+                values = vector.getMultipleHoldingRegisters(address, length, unitID);
+            } catch (error) {
+                callback(error);
+                return;
+            }
             if (values.length === length) {
                 for (i = 0; i < length; i++) {
                     tryAndHandlePromiseOrValue(i, values);


### PR DESCRIPTION
It's inconsistent that a rejected promise returned by getMultipleHoldingRegisters and a callback with and error are handled, but a synchronous throw is not. This PR fixes that.