### PR TITLE
fix: uncaught error in read device identification

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,7 +268,10 @@ function _readFC43(data, modbus, next) {
 
     let startAt = 8;
     const result = {};
-    for (let i = 0; i < numOfObjects; i++) {
+    // The modbus specification states that numOfObjects is the number of
+    // objects in the response, but the example on page 45 shows the total
+    // number over all responses. Therefore be careful about reading more data than available
+    for (let i = 0; i < numOfObjects && startAt < data.length; i++) {
         const objectId = parseInt(data.readUInt8(startAt));
         const objectLength = parseInt(data.readUInt8(startAt + 1));
         const startOfData = startAt + 2;

--- a/index.js
+++ b/index.js
@@ -496,51 +496,56 @@ function _onReceive(data) {
 
     /* parse incoming data
      */
-
-    switch (code) {
-        case 1:
-        case 2:
-            // Read Coil Status (FC=01)
-            // Read Input Status (FC=02)
-            _readFC2(data, next);
-            break;
-        case 3:
-        case 4:
-            // Read Input Registers (FC=04)
-            // Read Holding Registers (FC=03)
-            if (modbus._enron && !(transaction.nextDataAddress >= modbus._enronTables.shortRange[0] && transaction.nextDataAddress <= modbus._enronTables.shortRange[1])) {
-                _readFC3or4Enron(data, next);
-            } else {
-                _readFC3or4(data, next);
-            }
-            break;
-        case 5:
-            // Force Single Coil
-            _readFC5(data, next);
-            break;
-        case 6:
-            // Preset Single Register
-            if (modbus._enron && !(transaction.nextDataAddress >= modbus._enronTables.shortRange[0] && transaction.nextDataAddress <= modbus._enronTables.shortRange[1])) {
-                _readFC6Enron(data, next);
-            } else {
-                _readFC6(data, next);
-            }
-            break;
-        case 15:
-        case 16:
-            // Force Multiple Coils
-            // Preset Multiple Registers
-            _readFC16(data, next);
-            break;
-        case 17:
-            _readFC17(data, next);
-            break;
-        case 20:
-            _readFC20(data, transaction.next);
-            break;
-        case 43:
-            // read device identification
-            _readFC43(data, modbus, next);
+    try {
+        switch (code) {
+            case 1:
+            case 2:
+                // Read Coil Status (FC=01)
+                // Read Input Status (FC=02)
+                _readFC2(data, next);
+                break;
+            case 3:
+            case 4:
+                // Read Input Registers (FC=04)
+                // Read Holding Registers (FC=03)
+                if (modbus._enron && !(transaction.nextDataAddress >= modbus._enronTables.shortRange[0] && transaction.nextDataAddress <= modbus._enronTables.shortRange[1])) {
+                    _readFC3or4Enron(data, next);
+                } else {
+                    _readFC3or4(data, next);
+                }
+                break;
+            case 5:
+                // Force Single Coil
+                _readFC5(data, next);
+                break;
+            case 6:
+                // Preset Single Register
+                if (modbus._enron && !(transaction.nextDataAddress >= modbus._enronTables.shortRange[0] && transaction.nextDataAddress <= modbus._enronTables.shortRange[1])) {
+                    _readFC6Enron(data, next);
+                } else {
+                    _readFC6(data, next);
+                }
+                break;
+            case 15:
+            case 16:
+                // Force Multiple Coils
+                // Preset Multiple Registers
+                _readFC16(data, next);
+                break;
+            case 17:
+                _readFC17(data, next);
+                break;
+            case 20:
+                _readFC20(data, transaction.next);
+                break;
+            case 43:
+                // read device identification
+                _readFC43(data, modbus, next);
+        }
+    } catch (e) {
+        if (transaction.next) {
+            next(e);
+        }
     }
 }
 


### PR DESCRIPTION
I ran into the following error when communicating with a solar logger over Modbus TCP:
```
RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 and <= 12. Received 43
     at __node_internal_captureLargerStackTrace (node:internal/errors:490:5)
     at new NodeError (node:internal/errors:399:5)
     at boundsError (node:internal/buffer:88:9)
     at Buffer.readUInt8 (node:internal/buffer:254:5)
     at _readFC43 (/app/node_modules/modbus-serial/index.js:267:40)
     at ModbusRTU._onReceive (/app/node_modules/modbus-serial/index.js:538:13)
     at TcpPort.emit (node:events:513:28)
     at Socket.<anonymous> (/app/node_modules/modbus-serial/ports/tcpport.js:122:22)
     at Socket.emit (node:events:513:28)
     at addChunk (node:internal/streams/readable:324:12)
     at readableAddChunk (node:internal/streams/readable:297:9)
     at Readable.push (node:internal/streams/readable:234:10)
     at TCP.onStreamRead (node:internal/stream_base_commons:190:23)
```

Two problems here:
1. the error was uncaught, ie. it crashed my program
2. there are two interpretations of `numOfObjects`: the number of objects in the response or the number of objects in all responses combined. The [spec](https://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf) states the former, but  the example on page 45 shows the latter. The solar logger I was communicating with apparently uses the latter as well.

This PR addresses both problems.