### PR TITLE
Make Sockets accessible with TypeScript

### DIFF
--- a/ServerSerial.d.ts
+++ b/ServerSerial.d.ts
@@ -2,8 +2,10 @@ import * as events from 'events';
 import { SerialPortOpenOptions } from "serialport"
 import { FCallback, IServiceVector } from './ServerTCP';
 import { ErrorCallback } from '@serialport/stream';
+import ServerSerialPipeHandler from './servers/serverserial_pipe_handler';
 
 export class ServerSerial extends events.EventEmitter {
+    socks: Map<ServerSerialPipeHandler, 0>;
     constructor(vector: IServiceVector, options: IServerSerialOptions);
     close(cb: FCallback): void;
 }

--- a/ServerTCP.d.ts
+++ b/ServerTCP.d.ts
@@ -1,6 +1,8 @@
 import * as events from 'events';
+import net from "net";
 
 export class ServerTCP extends events.EventEmitter {
+    socks: Map<net.Socket, 0>
     constructor(vector: IServiceVector, options: IServerOptions);
     close(cb: FCallback): void;
 }


### PR DESCRIPTION
Trying to keep track of many sockets are connected to the current `ServerTCP`/`ServerSerial` instance.

While the `socks` property is already accessible, since it's not declared in the `.d.ts` files, TypeScript displays errors when trying to access the property.