### PR TITLE
feat: Allow close method to be used with Promises or callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -669,16 +669,27 @@ class ModbusRTU extends EventEmitter {
      *
      * @param {Function} callback the function to call next on close success
      *      or failure.
-     */
+     */    
     close(callback) {
-        // close the serial port if exist
-        if (this._port) {
-            this._port.removeAllListeners("data");
-            this._port.close(callback);
-        } else {
-            // nothing needed to be done
-            callback();
-        }
+        return new Promise((resolve, reject) => {
+            const cb = (err) => {
+                if (callback) {
+                    callback(err);
+                }
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            };
+    
+            if (this._port) {
+                this._port.removeAllListeners("data");
+                this._port.close(cb);
+            } else {
+                cb();
+            }
+        });
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -669,27 +669,16 @@ class ModbusRTU extends EventEmitter {
      *
      * @param {Function} callback the function to call next on close success
      *      or failure.
-     */    
+     */
     close(callback) {
-        return new Promise((resolve, reject) => {
-            const cb = (err) => {
-                if (callback) {
-                    callback(err);
-                }
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            };
-    
-            if (this._port) {
-                this._port.removeAllListeners("data");
-                this._port.close(cb);
-            } else {
-                cb();
-            }
-        });
+        // close the serial port if exist
+        if (this._port) {
+            this._port.removeAllListeners("data");
+            this._port.close(callback);
+        } else {
+            // nothing needed to be done
+            callback();
+        }
     }
 
     /**


### PR DESCRIPTION
First of all a big thank you for this fantastic module!
I was exploring the example folder looking for the `close()` method and I observed that it might be used in a way that suggests synchronous behavior. [polling_TCP.js](https://github.com/yaacov/node-modbus-serial/blob/master/examples/polling_TCP.js#L41)

Checking the implementation of the `close()` method I found out that it uses the Node.JS net.Socket class and in particular the `socket.end()` method which does not guarantee that the socket is fully closed immediately after calling `socket.end()`.

This pull request introduces Promise support to the close method and should not affect the existing usage. 
A callback can still be passed as argument.