### PR TITLE
Reduce the chances of multiple Modbus APUs per TCP frame

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -132,6 +132,7 @@ class TcpPort extends EventEmitter {
 
         this._client.on("connect", function() {
             self.openFlag = true;
+            self._writeCompleted = Promise.resolve();
             modbusSerialDebug("TCP port: signal connect");
             self._client.setNoDelay();
             handleCallback();
@@ -242,8 +243,8 @@ class TcpPort extends EventEmitter {
         });
 
         // send buffer to slave
-        let previousWritePromise = this._writeCompleted;
-        let newWritePromise = new Promise((resolveNewWrite, rejectNewWrite) => {
+        const previousWritePromise = this._writeCompleted;
+        const newWritePromise = new Promise((resolveNewWrite, rejectNewWrite) => {
             // Wait for the completion of any write that happened before.
             previousWritePromise.finally(() => {
                 try {

--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -133,6 +133,7 @@ class TcpPort extends EventEmitter {
         this._client.on("connect", function() {
             self.openFlag = true;
             modbusSerialDebug("TCP port: signal connect");
+            self._client.setNoDelay();
             handleCallback();
         });
 

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -15,12 +15,17 @@ class Socket extends EventEmitter {
         }
     }
 
+    setNoDelay(noDelay) {
+        return this;
+    }
+
     end() {
         this.emit("close", false);
     }
 
     write(data) {
         this._data = data;
+        return true;
     }
 
     receive(buffer) {
@@ -55,6 +60,6 @@ class Server extends EventEmitter {
 
 exports.Server = Server;
 
-exports.createServer = function(options, connectionListener) {
+exports.createServer = function (options, connectionListener) {
     return new Server(options, connectionListener);
 };

--- a/test/mocks/netMock.js
+++ b/test/mocks/netMock.js
@@ -15,7 +15,7 @@ class Socket extends EventEmitter {
         }
     }
 
-    setNoDelay(noDelay) {
+    setNoDelay() {
         return this;
     }
 
@@ -60,6 +60,6 @@ class Server extends EventEmitter {
 
 exports.Server = Server;
 
-exports.createServer = function (options, connectionListener) {
+exports.createServer = function(options, connectionListener) {
     return new Server(options, connectionListener);
 };

--- a/test/ports/tcpport.test.js
+++ b/test/ports/tcpport.test.js
@@ -122,10 +122,11 @@ describe("Modbus TCP port methods", function() {
             });
             port.open(function() {
                 port.write(Buffer.from("1103006B00037687", "hex"));
-
-                if (port._client._data.equals(Buffer.from("0001000000061103006B0003", "hex"))) {
-                    port._client.receive(Buffer.from("000100000006110366778899", "hex"));
-                }
+                port._writeCompleted.then(function() {
+                    if (port._client._data.equals(Buffer.from("0001000000061103006B0003", "hex"))) {
+                        port._client.receive(Buffer.from("000100000006110366778899", "hex"));
+                    }
+                });
             });
         });
 
@@ -136,18 +137,22 @@ describe("Modbus TCP port methods", function() {
             });
             port.open(function() {
                 port.write(Buffer.from("1103006B00037687", "hex"));
-
-                if (port._client._data.equals(Buffer.from("0002000000061103006B0003", "hex"))) {
-                    port._client.receive(Buffer.from("000200000003118304", "hex"));
-                }
+                port._writeCompleted.then(function() {
+                    if (port._client._data.equals(Buffer.from("0002000000061103006B0003", "hex"))) {
+                        port._client.receive(Buffer.from("000200000003118304", "hex"));
+                    }
+                });
             });
         });
     });
 
     describe("#write", function() {
-        it("should write a valid TCP message to the port", function() {
+        it("should write a valid TCP message to the port", function(done) {
             port.write(Buffer.from("1103006B00037687", "hex"));
-            expect(port._client._data.toString("hex")).to.equal("0003000000061103006b0003");
+            port._writeCompleted.then(function() {
+                expect(port._client._data.toString("hex")).to.equal("0003000000061103006b0003");
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
This attempts to reduce the likelihood of the problem described in #540, but unfortunately doesn't completely fix it.

* For every data we sent via the Modbus TCP socket we now wait for the [`drain` event](https://nodejs.org/api/net.html#event-drain) of the previous data in the hopes that the new data does not get merged into the same TCP frame.
* We set the [`NoDelay` flag](https://nodejs.org/api/net.html#socketsetnodelaynodelay).

Both changes seem to reduce the amount of TCP frames with more than one Modbus APU, but under very high throughput the can still be some of them. There seems to be no way of guaranteeing separate TCP packages short of using a raw socket and implementing the entire TCP stack manually, so I personally think this is a design flaw of the Modbus protocol and in the end I choose to fix the problem on the Modbus server side by accepting TCP packages with multiple APUs. Also, all other Modbus implementation which I found that were not written for bare metal have exactly the same problem.

I'm posting this here in case you still want to have an improvement over the current state. Sorry about all the whitespace changes, that was the auto formatter of my IDE.