### PR TITLE
fix: added close event for rtu buffered port

### DIFF
--- a/ports/rtubufferedport.js
+++ b/ports/rtubufferedport.js
@@ -81,6 +81,11 @@ class RTUBufferedPort extends EventEmitter {
             self.emit("error", error);
         });
 
+        // attach a close listner on the SerialPort object
+        this._client.on("close", function() {
+            self.emit("close");
+        });
+
         // register the port data event
         this._client.on("data", function onData(data) {
             // add data to buffer


### PR DESCRIPTION
It seems like in rtubufferedport.js the "close" event was missed, so the 
client.on('close', () => {
    console.log('Modbus closed');
});
never fires up.
Changed it according to tcprtubufferedport.js