### PR TITLE
Fix BUG when receiving splited TCP message

### DIFF
--- a/ports/tcpport.js
+++ b/ports/tcpport.js
@@ -154,6 +154,7 @@ class TcpPort extends EventEmitter {
         this._client.on("close", function(had_error) {
             if (self.openFlag)  {
                 self.openFlag = false;
+                self._clientRcvData = Buffer.alloc(0); // Reset the variable that storing all received data
                 modbusSerialDebug("TCP port: signal close: " + had_error);
                 handleCallback(had_error);
 


### PR DESCRIPTION
# Mainly
Sometimes modbus TCP message can be splited. 
This cause the on "data" function in tcpport is call multiple time but never with full data. 
With this fix, all received data are stored in a buffer and message is processed only when the buffer contain enougth data. 
The quantity of requested data is simply the size of MBAP + the length of the message (extracted from the MBAP)

# The Bug Was & the Fix

## Context
I try to read 4 holding register from a device. this device is often spliting message.
The device 4 register is [0, 0, 0, 1]

## The BUG
I have added (only for test) a console log in the on "data" function to log received data : 
<img width="714" height="34" alt="image" src="https://github.com/user-attachments/assets/4d3cbab1-cf92-4910-9e67-4dd488fad74f" />
<img width="465" height="46" alt="image" src="https://github.com/user-attachments/assets/9bc22826-775f-4a27-850f-4cc5d91b4514" />
- On line 1 > New data is received and comple
- On line 2 > Message is parsed and the function return as expected [0, 0, 0, 1]
- On line 3 > Only the first part of message is received
- On line 4 > Incomplete Message is parsed and the function retrun no data []
- On line 5 > The rest data of the message
- You can see that line 3 + line 5 is pretty the content of line 1 (the complete message). only the request ID change

## The Fix
I have added (only for test) 2 console log in the on "data" function : 
- The first log when message is incomplete and skip
- The second log when message processing is executed
- Both log received data and the content of the new buffer

<img width="800" height="52" alt="image" src="https://github.com/user-attachments/assets/18f824b2-1d15-4f56-8ed2-6ffd3ae29fc6" />

- On line 1 > New data is received and copy tp the new buffer. Not enougth data
- On line 2 > New data is received and append to the new buffer. Now, enougth data
- On line 3 > Message is parsed and the function return as expected [0, 0, 0, 1] 
- The BUG is Fixed !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP message buffering and parsing: incoming network chunks are now accumulated and validated before parsing, ensuring complete Modbus TCP frames are processed reliably.
  * Prevents errors from fragmented packets by only consuming bytes for fully processed messages, preserves message identifiers, and clears the receive buffer when a connection closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->