### PR TITLE
fix: add missing worker/ to files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ports",
     "servers",
     "utils",
+    "worker",
     "index.d.ts",
     "ModbusRTU.d.ts",
     "ServerTCP.d.ts",


### PR DESCRIPTION
## Summary

- Adds `"worker"` to the `files` array in `package.json`

## Problem

v8.0.24 introduced a `files` field in `package.json` but omitted the `worker/` directory. Since `apis/worker.js` requires `../worker/index`, the package fails at load time:

```
Error: Cannot find module '../worker/index'
```

This breaks all dependents using `^8.x` ranges.

**v8.0.23**: `worker/index.js` included (no `files` field, so everything was packaged)  
**v8.0.24**: `worker/index.js` missing (new `files` field doesn't list `worker`)

## Fix

One-line change: add `"worker"` to the `files` array.

Fixes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include the worker directory alongside core package files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->