### PR TITLE
add FC21

### DIFF
--- a/apis/promise.js
+++ b/apis/promise.js
@@ -98,6 +98,7 @@ const addPromiseAPI = function(Modbus) {
     cl.writeRegisters = _convert(cl.writeFC16);
     cl.reportServerID = _convert(cl.writeFC17);
     cl.readFileRecords = _convert(cl.writeFC20);
+    cl.writeFileRecords = _convert(cl.writeFC21);
     cl.maskWriteRegister = _convert(cl.writeFC22);
     cl.readWriteRegisters = _convert(cl.writeFC23);
     cl.readDeviceIdentification = _convert(cl.writeFC43);

--- a/index.js
+++ b/index.js
@@ -1270,7 +1270,7 @@ class ModbusRTU extends EventEmitter {
         const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
         buf.writeUInt8(address, 0);
         buf.writeUInt8(code, 1);
-        buf.writeUInt8(reqeustDataLength, 2);
+        buf.writeUInt8(requestDataLength, 2);
         buf.writeUInt8(6, 3); // ReferenceType
         buf.writeUInt16BE(fileNumber, 4);
         buf.writeUInt16BE(recordNumber, 6);

--- a/index.js
+++ b/index.js
@@ -250,6 +250,26 @@ function _readFC20(data,  next) {
 }
 
 /**
+ * Parse  the data fro Modbus -
+ * Write File Records
+ *
+ * @param {Buffer} buffer
+ * @param {Function} next
+ */
+function _readFC21(data,  next) {
+    const fileNumber = data.readUInt16BE(4);
+    const recordNumber = data.readUInt16BE(6);
+    const length = data.readUInt16BE(8);
+    const result = [];
+    for (let i = 10; i < length * 2 + 10; i++) {
+        const reg = data.readUInt8(i);
+        result.push(reg);
+    }
+    if(next)
+        next(null, { "data": result, "length": length, "fileNumber": fileNumber, "recordNumber": recordNumber });
+}
+
+/**
  * Parse the data for a Modbus -
  * Mask Write Register (FC=22)
  *
@@ -592,9 +612,12 @@ function _onReceive(data) {
                 break;
             case 17:
                 _readFC17(data, next);
-                break;
+                break
             case 20:
                 _readFC20(data, transaction.next);
+                break;;
+            case 21:
+                _readFC21(data, transaction.next);
                 break;
             case 22:
                 _readFC22(data, next);
@@ -1208,6 +1231,52 @@ class ModbusRTU extends EventEmitter {
         buf.writeUInt16BE(fileNumber, 4);
         buf.writeUInt16BE(recordNumber, 6);
         buf.writeUInt8(chunk, 9);
+        buf.writeUInt16LE(crc16(buf.subarray(0, -2)), codeLength);
+        _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
+    }
+
+    /**
+     * Write a Modbus "Write File Records" (FC=21) to serial port
+     * @param {number} address the slave unit address.
+     * @param {number} fileNumber the file number.
+     * @param {number} recordNumber the record number of file.
+     * @param {Buffer} data the data buffer to write.
+     * @param {Function} next;
+     */
+    writeFC21(address, fileNumber, recordNumber, data, next) {
+        if (this.isOpen !== true) {
+            if (next) next(new PortNotOpenError());
+            return;
+        }
+        // sanity check
+        if (typeof address === "undefined") {
+            if (next) next(new BadAddressError());
+            return;
+        }
+        const code = 21;
+        const codeLength = 10 + data.length;
+        const reqeustDataLength = 7 + data.length;
+        const recordLength = data.length / 2;
+
+        this._transactions[this._port._transactionIdWrite] = {
+            nextAddress: address,
+            nextCode: code,
+            lengthUnknown: true,
+            next: next
+        };
+        const buf = Buffer.alloc(codeLength + 2); // add 2 crc bytes
+        buf.writeUInt8(address, 0);
+        buf.writeUInt8(code, 1);
+        buf.writeUInt8(reqeustDataLength, 2);
+        buf.writeUInt8(6, 3); // ReferenceType
+        buf.writeUInt16BE(fileNumber, 4);
+        buf.writeUInt16BE(recordNumber, 6);
+        buf.writeUInt16BE(recordLength, 8);
+        let pos = 10;
+        for(const byte of data) {
+            buf.writeUInt8(byte, pos);
+            pos += 1;
+        }
         buf.writeUInt16LE(crc16(buf.subarray(0, -2)), codeLength);
         _writeBufferToPort.call(this, buf, this._port._transactionIdWrite);
     }

--- a/index.js
+++ b/index.js
@@ -1254,10 +1254,13 @@ class ModbusRTU extends EventEmitter {
             return;
         }
         const code = 21;
+        if (!data || data.length % 2 !== 0) {
+            if (next) next(new Error("Data length must be an even number of bytes"));
+            return;
+        }
         const codeLength = 10 + data.length;
-        const reqeustDataLength = 7 + data.length;
+        const requestDataLength = 7 + data.length;
         const recordLength = data.length / 2;
-
         this._transactions[this._port._transactionIdWrite] = {
             nextAddress: address,
             nextCode: code,

--- a/index.js
+++ b/index.js
@@ -612,7 +612,7 @@ function _onReceive(data) {
                 break;
             case 17:
                 _readFC17(data, next);
-                break
+                break;
             case 20:
                 _readFC20(data, transaction.next);
                 break;

--- a/index.js
+++ b/index.js
@@ -615,7 +615,7 @@ function _onReceive(data) {
                 break
             case 20:
                 _readFC20(data, transaction.next);
-                break;;
+                break;
             case 21:
                 _readFC21(data, transaction.next);
                 break;


### PR DESCRIPTION
add function write file records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Modbus “Write File Records” support (FC=21) for Modbus RTU.
  * Introduced a new `writeFC21` method for sending FC=21 requests.
  * Exposed a promise-based `writeFileRecords` method on Modbus instances for FC=21 operations.
* **Bug Fixes**
  * Improved FC=21 response handling to return file number, record number, record length, and payload bytes correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->